### PR TITLE
Fixes issue #6 "Integer params inside data array aren't taken in account"

### DIFF
--- a/Curl.class.php
+++ b/Curl.class.php
@@ -87,7 +87,7 @@ class Curl {
         $is_array_assoc = is_array_assoc($data);
 
         foreach ($data as $k => $value) {
-            if (is_string($value)) {
+            if (is_string($value) || is_int($value)) {
                 $brackets = $is_array_assoc ? '[' . $k . ']' : '[]';
                 $query[] = urlencode(is_null($key) ? $k : $key . $brackets) . '=' . rawurlencode($value);
             }


### PR DESCRIPTION
Makes the http_build_multi_query method to be also able to add integers inside the data array

Signed-off-by: Dani Sancas dani@sancas.es
