### PR TITLE
Fixes issue #8 "Nested arrays in data array are encoded at the same level as it's father array"

### DIFF
--- a/Curl.class.php
+++ b/Curl.class.php
@@ -92,7 +92,8 @@ class Curl {
                 $query[] = urlencode(is_null($key) ? $k : $key . $brackets) . '=' . rawurlencode($value);
             }
             else if (is_array($value)) {
-                $query[] = $this->http_build_multi_query($value, $k);
+                $nested = (is_null($key)) ? $k : $key."[".$k."]";
+                $query[] = $this->http_build_multi_query($value, $nested);
             }
         }
 


### PR DESCRIPTION
Makes the http_build_multi_query method to persist nested array indexes inside the data array

Signed-off-by: Dani Sancas dani@sancas.es
