### PR TITLE
Bugfix: If you make a GET request after a PUT request you still have the...

### DIFF
--- a/lib/Curl.class.php
+++ b/lib/Curl.class.php
@@ -46,6 +46,7 @@ class Curl {
     }
 
     public function get($url_mixed, $data=array()) {
+        $this->setOpt(CURLOPT_CUSTOMREQUEST, 'GET');
         if (is_array($url_mixed)) {
             $curl_multi = curl_multi_init();
             $this->_multi_parent = true;
@@ -90,6 +91,7 @@ class Curl {
 
     public function post($url, $data=array()) {
         $this->setOpt(CURLOPT_URL, $this->_buildURL($url));
+        $this->setOpt(CURLOPT_CUSTOMREQUEST, 'POST');
         $this->setOpt(CURLOPT_POST, true);
         $this->setOpt(CURLOPT_POSTFIELDS, $this->_postfields($data));
         return $this->exec();


### PR DESCRIPTION
... PUT value for CURLOPT_CUSTOMREQUEST, causing an error.

I have forced CURLOPT_CUSTOMREQUEST to 'GET' on get requests to avoid header overriding.
