### PR TITLE
Update authentication example to include error reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $curl->setCookie('key', 'value');
 $curl->get('http://www.example.com/');
 
 if ($curl->error) {
-    echo $curl->error_code;
+    echo "ERROR: " . $curl->error_code . ": " . $curl->error_message;
 }
 else {
     echo $curl->response;


### PR DESCRIPTION
Having just spend 10/20 mins trying to figure out what the error meant after copying this example I think it should include the error message by default.
