### PR TITLE
A few Fixes and improvements. (Temp file, Header setting/output, JSON encodeing)

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -56,7 +56,7 @@ class Curl
 
     protected function tmpHandle()
     {
-        if($this->tmp_handle_memory) {
+        if($this->handle_memory) {
             $handle =  fopen('php://memory', 'wb+');
         } else {
             $file_name = tempnam(sys_get_temp_dir(), 'curlHeaders');
@@ -69,7 +69,7 @@ class Curl
 
     public function tmpHandleMemory($memory = TRUE)
     {
-        $this->tmp_handle_memory = !empty($memory);
+        $this->handle_memory = !empty($memory);
     }
 
     public function peclHeaders($pecl = TRUE)

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -308,7 +308,7 @@ class Curl
         }
 
         if($option == CURLOPT_HTTPHEADER) {
-			$headers = array();
+            $headers = array();
             foreach($value as $key => $header_value) {
                 if(is_array($header_value)) {
                     foreach($header_value as $i => $header_value) {
@@ -318,7 +318,7 @@ class Curl
                     $headers[$key] = "$key: $header_value";
                 }
             }
-			$value = array_values($headers);
+            $value = array_values($headers);
         }
 
         $this->options[$option] = $value;
@@ -378,65 +378,65 @@ class Curl
         $http_headers = new CaseInsensitiveArray();
         $pecl = !empty($this->pecl_headers);
         $raw_headers = preg_split('/\r\n/', $raw_headers, 2, PREG_SPLIT_NO_EMPTY);
-		$first = array_shift($raw_headers);
-		if(!empty($raw_headers)) {
-			$raw_headers = current($raw_headers);
-			if($pecl) {
-				if (function_exists('http_parse_headers')) {
-					$headers = http_parse_headers($raw_headers);
-				} else {
-					$headers = array();
-					$key = '';
+        $first = array_shift($raw_headers);
+        if(!empty($raw_headers)) {
+            $raw_headers = current($raw_headers);
+            if($pecl) {
+                if (function_exists('http_parse_headers')) {
+                    $headers = http_parse_headers($raw_headers);
+                } else {
+                    $headers = array();
+                    $key = '';
 
-					foreach(explode("\n", $raw_headers) as $i => $h)
-					{
-						$h = explode(':', $h, 2);
+                    foreach(explode("\n", $raw_headers) as $i => $h)
+                    {
+                        $h = explode(':', $h, 2);
 
-						if (isset($h[1]))
-						{
-							if (!isset($headers[$h[0]]))
-								$headers[$h[0]] = trim($h[1]);
-							elseif (is_array($headers[$h[0]]))
-							{
-								$headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1]))); // [+]
-							}
-							else
-							{
-								$headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1]))); // [+]
-							}
+                        if (isset($h[1]))
+                        {
+                            if (!isset($headers[$h[0]]))
+                                $headers[$h[0]] = trim($h[1]);
+                            elseif (is_array($headers[$h[0]]))
+                            {
+                                $headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1]))); // [+]
+                            }
+                            else
+                            {
+                                $headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1]))); // [+]
+                            }
 
-							$key = $h[0];
-						}
-						else
-						{
-							if (substr($h[0], 0, 1) == "\t")
-								$headers[$key] .= "\r\n\t".trim($h[0]);
-							elseif (!$key)
-								$headers[0] = trim($h[0]);trim($h[0]);
-						}
-					}
+                            $key = $h[0];
+                        }
+                        else
+                        {
+                            if (substr($h[0], 0, 1) == "\t")
+                                $headers[$key] .= "\r\n\t".trim($h[0]);
+                            elseif (!$key)
+                                $headers[0] = trim($h[0]);trim($h[0]);
+                        }
+                    }
 
-				}
+                }
 
-				foreach(http_parse_headers($headers) as $key => $value) {
-					$http_headers[$key] = $value;
-				}
-			} else {
-				$raw_headers = preg_split('/\r\n/', $raw_headers, null, PREG_SPLIT_NO_EMPTY);
+                foreach(http_parse_headers($headers) as $key => $value) {
+                    $http_headers[$key] = $value;
+                }
+            } else {
+                $raw_headers = preg_split('/\r\n/', $raw_headers, null, PREG_SPLIT_NO_EMPTY);
 
-				foreach($raw_headers as $header) {
-					list($key, $value) = explode(':', $header, 2);
-					$key = trim($key);
-					$value = trim($value);
-					// Use isset() as array_key_exists() and ArrayAccess are not compatible.
-					if (isset($http_headers[$key])) {
-						$http_headers[$key] .= ',' . $value;
-					} else {
-						$http_headers[$key] = $value;
-					}
-				}
-			}
-		}
+                foreach($raw_headers as $header) {
+                    list($key, $value) = explode(':', $header, 2);
+                    $key = trim($key);
+                    $value = trim($value);
+                    // Use isset() as array_key_exists() and ArrayAccess are not compatible.
+                    if (isset($http_headers[$key])) {
+                        $http_headers[$key] .= ',' . $value;
+                    } else {
+                        $http_headers[$key] = $value;
+                    }
+                }
+            }
+        }
 
         return array(isset($first) ? $first : '', $http_headers);
     }

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -29,8 +29,8 @@ class Curl
     private $error_function = null;
     private $complete_function = null;
 
-    private $handle_file   = FALSE;
-    private $pecl_headers  = FALSE;
+    private $handle_file  = FALSE;
+    private $pecl_headers = FALSE;
 
     public $curl;
     public $curls;
@@ -86,7 +86,8 @@ class Curl
         return $handle;
     }
 
-    public function buildBaseURL($url, Array $url_subs = array()) {
+    public function buildBaseURL($url, Array $url_subs = array())
+    {
         return preg_replace_callback(self::$substitutive_url_preg, function($matches) use ($url_subs) {
             $part = null;
             if(isset($matches[1]) && isset($url_subs[$matches[1]])) {
@@ -101,13 +102,15 @@ class Curl
         }, $url);
     }
 
-    public function setURL($url, Array $url_subs = array(), $data = array()) {
+    public function setURL($url, Array $url_subs = array(), $data = array())
+    {
         $this->base_url = $this->buildBaseURL($url, $url_subs);
         $this->url      = $this->buildURL($this->base_url, $data);
         return $this->setOpt(CURLOPT_URL, $this->url);
     }
 
-    public function setRequestType($type) {
+    public function setRequestType($type)
+    {
         $TYPE = strtoupper($type);
         $options = array(CURLOPT_CUSTOMREQUEST => $TYPE);
         if($TYPE == 'GET') {
@@ -226,7 +229,7 @@ class Curl
     public function options($url, $data = array(), Array $url_subs = array())
     {
         $this->setURL($url, $url_subs);
-		$this->setOpt(CURLOPT_URL, $this->buildURL($this->url, $data));
+        $this->setOpt(CURLOPT_URL, $this->buildURL($this->url, $data));
         $this->unsetHeader('Content-Length');
         $this->setRequestType('OPTIONS');
         return $this->exec();
@@ -329,7 +332,8 @@ class Curl
         $this->setOpt(CURLOPT_COOKIEJAR, $cookie_jar);
     }
 
-    public function setOpts(Array $options, $_ch = null) {
+    public function setOpts(Array $options, $_ch = null)
+    {
         $return = true;
         $ch = $_ch === null ? $this->curl : $_ch;
         foreach((array) $options as $option => $value) {
@@ -403,7 +407,8 @@ class Curl
         return $url . (empty($data) ? '' : '?' . http_build_query($data));
     }
 
-    public function normalizeContentType($headers = null) {
+    public function normalizeContentType($headers = null)
+    {
         if(!(is_array($headers) || $headers instanceof CaseInsensitiveArray)) {
             $headers = $this->headers;
         }

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -431,6 +431,11 @@ class Curl
 
         return array($response, $raw_response);
     }
+    
+    protected function isJSON()
+    {
+        return isset($this->headers['Content-Type']) && preg_match('~^application/(?:json|vnd\.api\+json)~i', $this->headers['Content-Type']);
+    }
 
     private function parseResponseHeaders($raw_response_headers)
     {
@@ -454,7 +459,9 @@ class Curl
 
     private function postfields($data)
     {
-        if (is_array($data)) {
+        if(!is_string($data) && $this->isJSON()) {
+            $data = json_encode($data);
+        } elseif (is_array($data)) {
             if (self::is_array_multidim($data)) {
                 $data = self::http_build_multi_query($data);
             } else {

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -209,8 +209,8 @@ class Curl
 
     public function delete($url, $data = array(), Array $url_subs = array())
     {
-        $this->setURL($url, $url_subs, $data);
-        //$this->setOpt(CURLOPT_URL, $this->buildURL($this->url, $data));
+        $this->setURL($url, $url_subs);
+        $this->setOpt(CURLOPT_URL, $this->buildURL($this->url, $data));
         $this->unsetHeader('Content-Length');
         $this->setRequestType('DELETE');
         return $this->exec();

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -246,12 +246,12 @@ class Curl
     {
         $this->headers[$key] = $value;
 
-		$headers = array();
-		foreach((array) $this->headers as $key => $value) {
-			foreach((array) $value as $value) {
-				$headers[] = "$key: $value";
-			}
-		}
+        $headers = array();
+        foreach((array) $this->headers as $key => $value) {
+            foreach((array) $value as $value) {
+                $headers[] = "$key: $value";
+            }
+        }
         $this->setOpt(CURLOPT_HTTPHEADER, $headers);
     }
 

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -16,6 +16,9 @@ class Curl
     private $success_function = null;
     private $error_function = null;
     private $complete_function = null;
+    
+    private $handle_memory = TRUE;
+    private $pecl_headers = FALSE;
 
     public $curl;
     public $curls;

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -48,7 +48,7 @@ class Curl
     public $response = null;
     public $raw_response = null;
 
-    public function __construct($flags = FALSE)
+    public function __construct(Array $options = array(), $flags = FALSE)
     {
         if (!extension_loaded('curl')) {
             throw new \ErrorException('cURL library is not loaded');
@@ -57,10 +57,14 @@ class Curl
         $this->pecl_headers = ($flags & self::HEADERS_PECL);
         $this->handle_file  = ($flags & self::TMP_FILE);
 
+        $options += array(
+            CURLINFO_HEADER_OUT => true,
+            CURLOPT_RETURNTRANSFER => true,
+        );
+
         $this->curl = curl_init();
         $this->setDefaultUserAgent();
-        $this->setOpt(CURLINFO_HEADER_OUT, true);
-        $this->setOpt(CURLOPT_RETURNTRANSFER, true);
+        $this->setOpts($options);
     }
 
     protected function tmpHandle()
@@ -302,6 +306,14 @@ class Curl
     public function setCookieJar($cookie_jar)
     {
         $this->setOpt(CURLOPT_COOKIEJAR, $cookie_jar);
+    }
+
+    public function setOpts(Array $options, $_ch = null) {
+        $return = true;
+        foreach((array) $options as $option => $value) {
+            $return = $this->setOpt($option, $value, $_ch) && $return;
+        }
+        return $return;
     }
 
     public function setOpt($option, $value, $_ch = null)

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -225,7 +225,8 @@ class Curl
 
     public function options($url, $data = array(), Array $url_subs = array())
     {
-        $this->setURL($url, $url_subs, $data);
+        $this->setURL($url, $url_subs);
+		$this->setOpt(CURLOPT_URL, $this->buildURL($this->url, $data));
         $this->unsetHeader('Content-Length');
         $this->setRequestType('OPTIONS');
         return $this->exec();

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -247,8 +247,8 @@ class Curl
         $this->headers[$key] = $value;
 
 		$headers = array();
-		foreach((array) $this->headers as $key => $header_value) {
-			foreach((array) $value as $header_value) {
+		foreach((array) $this->headers as $key => $value) {
+			foreach((array) $value as $value) {
 				$headers[] = "$key: $value";
 			}
 		}

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -53,6 +53,24 @@ class Curl
         $this->setOpt(CURLINFO_HEADER_OUT, true);
         $this->setOpt(CURLOPT_RETURNTRANSFER, true);
     }
+    
+    protected function tmpHandle()
+    {
+        if($this->tmp_handle_memory) {
+            $handle =  fopen('php://memory', 'wb+');
+        } else {
+            $file_name = tempnam(sys_get_temp_dir(), 'curlHeaders');
+            $handle = fopen($file_name, 'wb+');
+            unlink($file_name);
+        }
+        
+        return $handle;
+    }
+    
+    public function tmpHandleMemory($memory = TRUE)
+    {
+        $this->tmp_handle_memory = !empty($memory);
+    }
 
     public function get($url_mixed, $data = array())
     {
@@ -440,7 +458,7 @@ class Curl
     {
         $ch = $_ch === null ? $this : $_ch;
 
-        $response_headers_fh = fopen('php://memory', 'wb+');
+        $response_headers_fh = $this->tmpHandle();
         $ch->setOpt(CURLOPT_WRITEHEADER, $response_headers_fh);
 
         if ($ch->multi_child) {

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -16,7 +16,7 @@ class Curl
     private $success_function = null;
     private $error_function = null;
     private $complete_function = null;
-    
+
     private $handle_memory = TRUE;
     private $pecl_headers = FALSE;
 
@@ -53,7 +53,7 @@ class Curl
         $this->setOpt(CURLINFO_HEADER_OUT, true);
         $this->setOpt(CURLOPT_RETURNTRANSFER, true);
     }
-    
+
     protected function tmpHandle()
     {
         if($this->tmp_handle_memory) {
@@ -63,15 +63,15 @@ class Curl
             $handle = fopen($file_name, 'wb+');
             unlink($file_name);
         }
-        
+
         return $handle;
     }
-    
+
     public function tmpHandleMemory($memory = TRUE)
     {
         $this->tmp_handle_memory = !empty($memory);
     }
-    
+
     public function peclHeaders($pecl = TRUE)
     {
         $this->pecl_headers = !empty($pecl);
@@ -234,14 +234,14 @@ class Curl
         $this->setOpt(CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
         $this->setOpt(CURLOPT_USERPWD, $username . ':' . $password);
     }
-    
+
     public function setHeaders(Array $headers)
     {
         foreach($headers as $key => $value) {
             $this->setHeader($key, $value);
         }
     }
-    
+
     public function setHeader($key, $value)
     {
         $this->headers[$key] = $value;
@@ -306,7 +306,7 @@ class Curl
         if (in_array($option, array_keys($required_options), true) && !($value === true)) {
             trigger_error($required_options[$option] . ' is a required option', E_USER_WARNING);
         }
-        
+
         if($option == CURLOPT_HTTPHEADER) {
             foreach($value as $key => $header_value) {
                 if(is_array($header_value)) {
@@ -317,7 +317,7 @@ class Curl
                     $value[$key] = "$key: $header_value";
                 }
             }
-            
+
         }
 
         $this->options[$option] = $value;
@@ -378,17 +378,17 @@ class Curl
         $pecl = !empty($this->pecl_headers);
         list($first, $raw_headers) = preg_split('/\r\n/', $raw_headers, 2, PREG_SPLIT_NO_EMPTY);
         if($pecl) {
-			
+
 			if (function_exists('http_parse_headers')) {
 				$headers = http_parse_headers($raw_headers);
 			} else {
 				$headers = array();
 				$key = '';
-			
+
 				foreach(explode("\n", $raw_headers) as $i => $h)
 				{
 					$h = explode(':', $h, 2);
-			
+
 					if (isset($h[1]))
 					{
 						if (!isset($headers[$h[0]]))
@@ -401,7 +401,7 @@ class Curl
 						{
 							$headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1]))); // [+]
 						}
-			
+
 						$key = $h[0];
 					}
 					else
@@ -412,16 +412,16 @@ class Curl
 							$headers[0] = trim($h[0]);trim($h[0]);
 					}
 				}
-			
+
 			}
-			
+
             foreach(http_parse_headers($headers) as $key => $value) {
                 $http_headers[$key] = $value;
             }
-			
+
         } else {
             $raw_headers = preg_split('/\r\n/', $raw_headers, null, PREG_SPLIT_NO_EMPTY);
-            
+
             foreach($raw_headers as $header) {
                 list($key, $value) = explode(':', $header, 2);
                 $key = trim($key);
@@ -469,7 +469,7 @@ class Curl
 
         return array($response, $raw_response);
     }
-    
+
     protected function isJSON()
     {
         return isset($this->headers['Content-Type']) && preg_match('~^application/(?:json|vnd\.api\+json)~i', $this->headers['Content-Type']);

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -547,7 +547,6 @@ class Curl
             return fwrite($response_headers_fh, $data);
         });
 
-
         if ($ch->multi_child) {
             $ch->raw_response = curl_multi_getcontent($ch->curl);
         } else {

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -98,8 +98,9 @@ class Curl
                 $curl->multi_child = true;
 
                 $curl->base_url = $url;
-                $curl->url = $this->buildURL($url, $data);
+                $curl->url = $this->buildURL($curl->base_url, $data);
                 $curl->setOpt(CURLOPT_URL, $curl->url, $curl->curl);
+
                 $curl->setOpt(CURLOPT_CUSTOMREQUEST, 'GET');
                 $curl->setOpt(CURLOPT_HTTPGET, true);
                 $this->call($this->before_send_function, $curl);
@@ -137,9 +138,11 @@ class Curl
                 $this->exec($ch);
             }
         } else {
+
             $this->base_url = $url_mixed;
-            $this->url = $this->buildURL($url_mixed, $data);
+            $this->url = $this->buildURL($this->base_url, $data);
             $this->setOpt(CURLOPT_URL, $this->url);
+
             $this->setOpt(CURLOPT_CUSTOMREQUEST, 'GET');
             $this->setOpt(CURLOPT_HTTPGET, true);
             return $this->exec();
@@ -153,8 +156,9 @@ class Curl
         }
 
         $this->base_url = $url;
-        $this->url = $url;
+        $this->url = $this->base_url;
         $this->setOpt(CURLOPT_URL, $this->url);
+
         $this->setOpt(CURLOPT_CUSTOMREQUEST, 'POST');
         $this->setOpt(CURLOPT_POST, true);
         $this->setOpt(CURLOPT_POSTFIELDS, $this->postfields($data));
@@ -164,23 +168,28 @@ class Curl
     public function put($url, $data = array())
     {
         $this->base_url = $url;
-        $this->url = $url;
+        $this->url = $this->base_url;
         $this->setOpt(CURLOPT_URL, $this->url);
+
         $this->setOpt(CURLOPT_CUSTOMREQUEST, 'PUT');
+
         $put_data = $this->postfields($data);
+
         if (empty($this->options[CURLOPT_INFILE]) && empty($this->options[CURLOPT_INFILESIZE])) {
             $this->setHeader('Content-Length', strlen($put_data));
         }
         $this->setOpt(CURLOPT_POSTFIELDS, $put_data);
+
         return $this->exec();
     }
 
     public function patch($url, $data = array())
     {
         $this->base_url = $url;
-        $this->url = $url;
-        $this->unsetHeader('Content-Length');
+        $this->url = $this->base_url;
         $this->setOpt(CURLOPT_URL, $this->url);
+
+        $this->unsetHeader('Content-Length');
         $this->setOpt(CURLOPT_CUSTOMREQUEST, 'PATCH');
         $this->setOpt(CURLOPT_POSTFIELDS, $data);
         return $this->exec();
@@ -189,9 +198,10 @@ class Curl
     public function delete($url, $data = array())
     {
         $this->base_url = $url;
-        $this->url = $url;
-        $this->unsetHeader('Content-Length');
+        $this->url = $this->base_url;
         $this->setOpt(CURLOPT_URL, $this->buildURL($this->url, $data));
+
+        $this->unsetHeader('Content-Length');
         $this->setOpt(CURLOPT_CUSTOMREQUEST, 'DELETE');
         return $this->exec();
     }
@@ -199,8 +209,9 @@ class Curl
     public function head($url, $data = array())
     {
         $this->base_url = $url;
-        $this->url = $this->buildURL($url, $data);
+        $this->url = $this->buildURL($this->base_url, $data);
         $this->setOpt(CURLOPT_URL, $this->url);
+
         $this->setOpt(CURLOPT_CUSTOMREQUEST, 'HEAD');
         $this->setOpt(CURLOPT_NOBODY, true);
         return $this->exec();
@@ -209,9 +220,10 @@ class Curl
     public function options($url, $data = array())
     {
         $this->base_url = $url;
-        $this->url = $url;
+        $this->url = $this->base_url;
+        $this->setOpt(CURLOPT_URL, $this->buildURL($this->url, $data));
+
         $this->unsetHeader('Content-Length');
-        $this->setOpt(CURLOPT_URL, $this->buildURL($url, $data));
         $this->setOpt(CURLOPT_CUSTOMREQUEST, 'OPTIONS');
         return $this->exec();
     }

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -235,24 +235,28 @@ class Curl
         $this->setOpt(CURLOPT_USERPWD, $username . ':' . $password);
     }
 
+    protected function buildHeaders(Array $source_headers) {
+        $headers = array();
+        foreach((array) $source_headers as $key => $value) {
+            foreach((array) $value as $value) {
+                $headers[] = "$key: $value";
+            }
+        }
+        return $headers;
+    }
+
     public function setHeaders(Array $headers)
     {
         foreach($headers as $key => $value) {
-            $this->setHeader($key, $value);
+            $this->headers[$key] = $value;
         }
+        $this->setOpt(CURLOPT_HTTPHEADER, $this->buildHeaders($this->headers));
     }
 
     public function setHeader($key, $value)
     {
         $this->headers[$key] = $value;
-
-        $headers = array();
-        foreach((array) $this->headers as $key => $value) {
-            foreach((array) $value as $value) {
-                $headers[] = "$key: $value";
-            }
-        }
-        $this->setOpt(CURLOPT_HTTPHEADER, $headers);
+        $this->setOpt(CURLOPT_HTTPHEADER, $this->buildHeaders($this->headers));
     }
 
     public function unsetHeader($key)

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -376,9 +376,9 @@ class Curl
     {
         $http_headers = new CaseInsensitiveArray();
         $pecl = !empty($this->pecl_headers);
-        list($first, $raw_headers) = preg_split('/\r\n/', $raw_headers, 2, PREG_SPLIT_NO_EMPTY);
+        $raw_headers = preg_split('/\r\n/', $raw_headers, 2, PREG_SPLIT_NO_EMPTY);
+		$first = array_shift($raw_headers);
         if($pecl) {
-
 			if (function_exists('http_parse_headers')) {
 				$headers = http_parse_headers($raw_headers);
 			} else {

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -605,3 +605,41 @@ class CaseInsensitiveArray implements \ArrayAccess, \Countable, \Iterator
         reset($this->container);
     }
 }
+
+if (!function_exists('http_parse_headers')) {
+    function http_parse_headers($raw_headers)
+    {
+        $headers = array();
+        $key = '';
+
+        foreach(explode("\n", $raw_headers) as $i => $h)
+        {
+            $h = explode(':', $h, 2);
+
+            if (isset($h[1]))
+            {
+                if (!isset($headers[$h[0]]))
+                    $headers[$h[0]] = trim($h[1]);
+                elseif (is_array($headers[$h[0]]))
+                {
+                    $headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1]))); // [+]
+                }
+                else
+                {
+                    $headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1]))); // [+]
+                }
+
+                $key = $h[0];
+            }
+            else
+            {
+                if (substr($h[0], 0, 1) == "\t")
+                    $headers[$key] .= "\r\n\t".trim($h[0]);
+                elseif (!$key)
+                    $headers[0] = trim($h[0]);trim($h[0]);
+            }
+        }
+
+        return $headers;
+    }
+}

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -245,7 +245,14 @@ class Curl
     public function setHeader($key, $value)
     {
         $this->headers[$key] = $value;
-        $this->setOpt(CURLOPT_HTTPHEADER, $this->headers);
+
+		$headers = array();
+		foreach((array) $this->headers as $key => $header_value) {
+			foreach((array) $value as $header_value) {
+				$headers[] = "$key: $value";
+			}
+		}
+        $this->setOpt(CURLOPT_HTTPHEADER, $headers);
     }
 
     public function unsetHeader($key)
@@ -305,20 +312,6 @@ class Curl
 
         if (in_array($option, array_keys($required_options), true) && !($value === true)) {
             trigger_error($required_options[$option] . ' is a required option', E_USER_WARNING);
-        }
-
-        if($option == CURLOPT_HTTPHEADER) {
-            $headers = array();
-            foreach($value as $key => $header_value) {
-                if(is_array($header_value)) {
-                    foreach($header_value as $i => $header_value) {
-                        $headers[$key.$i] = "$key: $header_value";
-                    }
-                } else {
-                    $headers[$key] = "$key: $header_value";
-                }
-            }
-            $value = array_values($headers);
         }
 
         $this->options[$option] = $value;

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -378,9 +378,47 @@ class Curl
         $pecl = !empty($this->pecl_headers);
         list($first, $raw_headers) = preg_split('/\r\n/', $raw_headers, 2, PREG_SPLIT_NO_EMPTY);
         if($pecl) {
-            foreach(http_parse_headers($raw_headers) as $key => $value) {
+			
+			if (function_exists('http_parse_headers')) {
+				$headers = http_parse_headers($raw_headers);
+			} else {
+				$headers = array();
+				$key = '';
+			
+				foreach(explode("\n", $raw_headers) as $i => $h)
+				{
+					$h = explode(':', $h, 2);
+			
+					if (isset($h[1]))
+					{
+						if (!isset($headers[$h[0]]))
+							$headers[$h[0]] = trim($h[1]);
+						elseif (is_array($headers[$h[0]]))
+						{
+							$headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1]))); // [+]
+						}
+						else
+						{
+							$headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1]))); // [+]
+						}
+			
+						$key = $h[0];
+					}
+					else
+					{
+						if (substr($h[0], 0, 1) == "\t")
+							$headers[$key] .= "\r\n\t".trim($h[0]);
+						elseif (!$key)
+							$headers[0] = trim($h[0]);trim($h[0]);
+					}
+				}
+			
+			}
+			
+            foreach(http_parse_headers($headers) as $key => $value) {
                 $http_headers[$key] = $value;
             }
+			
         } else {
             $raw_headers = preg_split('/\r\n/', $raw_headers, null, PREG_SPLIT_NO_EMPTY);
             
@@ -661,43 +699,5 @@ class CaseInsensitiveArray implements \ArrayAccess, \Countable, \Iterator
     public function rewind()
     {
         reset($this->container);
-    }
-}
-
-if (!function_exists('http_parse_headers')) {
-    function http_parse_headers($raw_headers)
-    {
-        $headers = array();
-        $key = '';
-
-        foreach(explode("\n", $raw_headers) as $i => $h)
-        {
-            $h = explode(':', $h, 2);
-
-            if (isset($h[1]))
-            {
-                if (!isset($headers[$h[0]]))
-                    $headers[$h[0]] = trim($h[1]);
-                elseif (is_array($headers[$h[0]]))
-                {
-                    $headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1]))); // [+]
-                }
-                else
-                {
-                    $headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1]))); // [+]
-                }
-
-                $key = $h[0];
-            }
-            else
-            {
-                if (substr($h[0], 0, 1) == "\t")
-                    $headers[$key] .= "\r\n\t".trim($h[0]);
-                elseif (!$key)
-                    $headers[0] = trim($h[0]);trim($h[0]);
-            }
-        }
-
-        return $headers;
     }
 }

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -330,6 +330,7 @@ class Curl
 
     public function setOpts(Array $options, $_ch = null) {
         $return = true;
+        $ch = $_ch === null ? $this->curl : $_ch;
         foreach((array) $options as $option => $value) {
             $return = $this->setOpt($option, $value, $_ch) && $return;
         }

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -378,62 +378,64 @@ class Curl
         $pecl = !empty($this->pecl_headers);
         $raw_headers = preg_split('/\r\n/', $raw_headers, 2, PREG_SPLIT_NO_EMPTY);
 		$first = array_shift($raw_headers);
-        if($pecl) {
-			if (function_exists('http_parse_headers')) {
-				$headers = http_parse_headers($raw_headers);
-			} else {
-				$headers = array();
-				$key = '';
+		if(!empty($raw_headers)) {
+			$raw_headers = current($raw_headers);
+			if($pecl) {
+				if (function_exists('http_parse_headers')) {
+					$headers = http_parse_headers($raw_headers);
+				} else {
+					$headers = array();
+					$key = '';
 
-				foreach(explode("\n", $raw_headers) as $i => $h)
-				{
-					$h = explode(':', $h, 2);
-
-					if (isset($h[1]))
+					foreach(explode("\n", $raw_headers) as $i => $h)
 					{
-						if (!isset($headers[$h[0]]))
-							$headers[$h[0]] = trim($h[1]);
-						elseif (is_array($headers[$h[0]]))
+						$h = explode(':', $h, 2);
+
+						if (isset($h[1]))
 						{
-							$headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1]))); // [+]
+							if (!isset($headers[$h[0]]))
+								$headers[$h[0]] = trim($h[1]);
+							elseif (is_array($headers[$h[0]]))
+							{
+								$headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1]))); // [+]
+							}
+							else
+							{
+								$headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1]))); // [+]
+							}
+
+							$key = $h[0];
 						}
 						else
 						{
-							$headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1]))); // [+]
+							if (substr($h[0], 0, 1) == "\t")
+								$headers[$key] .= "\r\n\t".trim($h[0]);
+							elseif (!$key)
+								$headers[0] = trim($h[0]);trim($h[0]);
 						}
+					}
 
-						$key = $h[0];
-					}
-					else
-					{
-						if (substr($h[0], 0, 1) == "\t")
-							$headers[$key] .= "\r\n\t".trim($h[0]);
-						elseif (!$key)
-							$headers[0] = trim($h[0]);trim($h[0]);
-					}
 				}
 
+				foreach(http_parse_headers($headers) as $key => $value) {
+					$http_headers[$key] = $value;
+				}
+			} else {
+				$raw_headers = preg_split('/\r\n/', $raw_headers, null, PREG_SPLIT_NO_EMPTY);
+
+				foreach($raw_headers as $header) {
+					list($key, $value) = explode(':', $header, 2);
+					$key = trim($key);
+					$value = trim($value);
+					// Use isset() as array_key_exists() and ArrayAccess are not compatible.
+					if (isset($http_headers[$key])) {
+						$http_headers[$key] .= ',' . $value;
+					} else {
+						$http_headers[$key] = $value;
+					}
+				}
 			}
-
-            foreach(http_parse_headers($headers) as $key => $value) {
-                $http_headers[$key] = $value;
-            }
-
-        } else {
-            $raw_headers = preg_split('/\r\n/', $raw_headers, null, PREG_SPLIT_NO_EMPTY);
-
-            foreach($raw_headers as $header) {
-                list($key, $value) = explode(':', $header, 2);
-                $key = trim($key);
-                $value = trim($value);
-                // Use isset() as array_key_exists() and ArrayAccess are not compatible.
-                if (isset($http_headers[$key])) {
-                    $http_headers[$key] .= ',' . $value;
-                } else {
-                    $http_headers[$key] = $value;
-                }
-            }
-        }
+		}
 
         return array(isset($first) ? $first : '', $http_headers);
     }

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -308,16 +308,17 @@ class Curl
         }
 
         if($option == CURLOPT_HTTPHEADER) {
+			$headers = array();
             foreach($value as $key => $header_value) {
                 if(is_array($header_value)) {
                     foreach($header_value as $i => $header_value) {
-                        $value[$key.$i] = "$key: $header_value";
+                        $headers[$key.$i] = "$key: $header_value";
                     }
                 } else {
-                    $value[$key] = "$key: $header_value";
+                    $headers[$key] = "$key: $header_value";
                 }
             }
-
+			$value = array_values($headers);
         }
 
         $this->options[$option] = $value;


### PR DESCRIPTION
This pull contains a number of improvements:
* An anonymous function to handle writing to `php://memory` to mitigate (https://bugs.php.net/bug.php?id=43468).
* Support for PECL-style Header output (multi-dimensional associative arrays).
* Support for setting a group of headers.
* Support for setting Headers in the PECL-style (multi-dimensional associative arrays).
* Support for automatic JSON encoding of the POST contents if the 'Content-Type' is application/json.
* Supports URLs with place-holders (Restful URLs).
* Added methods:
 * `setRequestType()` - Sets the `CURLOPT_CUSTOMREQUEST` to Uppercase Request Type, and sets `CURLOPT_HTTPGET`, `CURLOPT_POST`, `CURLOPT_NOBODY` depending on the type.
 * `setURL()` - Sets the `base_url` to the provided URL with optional place-holder substitution, sets `url` to the `base_url` with optional `GET` request appended, sets `CURLOPT_URL` to the resulting `url`.
 * `buildBaseURL()` - Performs place-holder substitution on a provided URL with the provided `$url_subs`.
 * `normalizeContentType()` - Filters a set of Headers and resolves a Lower Case normalized representation of the Content Type (xml/json at this time).
 * more.