### PR TITLE
Fixed cpu draining with parallel requests

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -88,6 +88,7 @@ class Curl
             }
 
             do {
+                curl_multi_select($curl_multi);
                 $status = curl_multi_exec($curl_multi, $active);
             } while ($status === CURLM_CALL_MULTI_PERFORM || $active);
 


### PR DESCRIPTION
Why not add that call so it stops the loop if curl is not ready? That way the loop won't take all the available cpu.