### PR TITLE
Add setDigestAuthentication to Curl class

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -291,6 +291,13 @@ class Curl
         $this->setOpt(CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
         $this->setOpt(CURLOPT_USERPWD, $username . ':' . $password);
     }
+    
+    public function setDigestAuthentication($username, $password = '')
+    {
+        $this->setOpt(CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+        $this->setOpt(CURLOPT_USERPWD, $username . ':' . $password);
+        $this->setOpt(CURLOPT_RETURNTRANSFER, true);
+    }
 
     public function setCookie($key, $value)
     {


### PR DESCRIPTION
New function **setDigestAuthentication** works mostly like setBasicAuthentication, except it sets:
- **CURLOPT_HTTPAUTH** to **CURLAUTH_DIGEST** and
- **CURLOPT_RETURNTRANSFER** to **true**

Reason for the change is that i want to use this class for HTTP requests, but i need a DIGEST authentication badly and don't want to extend my own implementation.

