### PR TITLE
Fix a memory leak

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -133,6 +133,7 @@ class Curl
         if (is_resource($this->curl)) {
             curl_close($this->curl);
         }
+        $this->json_decoder = null;
     }
 
     public function complete($callback)

--- a/tests/PHPCurlClass/PHPCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPCurlClassTest.php
@@ -669,7 +669,8 @@ class CurlTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('cookie1=scrumptious,cookie2=mouthwatering', $test->curl->response_headers['Set-Cookie']);
     }
 
-    public function testDefaultTimeout() {
+    public function testDefaultTimeout()
+    {
         $test = new Test();
         $test->server('timeout', 'GET', array(
             'seconds' => '31',
@@ -681,7 +682,8 @@ class CurlTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($test->curl->http_error);
     }
 
-    public function testTimeoutError() {
+    public function testTimeoutError()
+    {
         $test = new Test();
         $test->curl->setTimeout(5);
         $test->server('timeout', 'GET', array(
@@ -694,7 +696,8 @@ class CurlTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($test->curl->http_error);
     }
 
-    public function testTimeout() {
+    public function testTimeout()
+    {
         $test = new Test();
         $test->curl->setTimeout(10);
         $test->server('timeout', 'GET', array(


### PR DESCRIPTION
test:
```php
function test_2() {
    $url = 'http://127.0.0.1:8000/';
    $ch = new \Curl\Curl();
    $ch->get($url);
    $ch->close();
}

for ($i = 0; $i < 5; $i++ ) {
    echo str_repeat('-', 80) . "\n";
    echo 'memory usage before: ' . memory_get_usage() . "\n";
    test_2();
    echo 'memory usage after:  ' . memory_get_usage() . "\n";
    sleep(1);
}
```

before:
```
--------------------------------------------------------------------------------
memory usage before: 435808
memory usage after:  442808
--------------------------------------------------------------------------------
memory usage before: 442808
memory usage after:  447176
--------------------------------------------------------------------------------
memory usage before: 447176
memory usage after:  451544
--------------------------------------------------------------------------------
memory usage before: 451544
memory usage after:  455912
--------------------------------------------------------------------------------
memory usage before: 455912
memory usage after:  460280
```

after:
```
--------------------------------------------------------------------------------
memory usage before: 436192
memory usage after:  438880
--------------------------------------------------------------------------------
memory usage before: 438880
memory usage after:  438880
--------------------------------------------------------------------------------
memory usage before: 438880
memory usage after:  438880
--------------------------------------------------------------------------------
memory usage before: 438880
memory usage after:  438880
--------------------------------------------------------------------------------
memory usage before: 438880
memory usage after:  438880
```

#173 