### PR TITLE
Remove circular reference during cleanup

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -133,6 +133,7 @@ class Curl
         if (is_resource($this->curl)) {
             curl_close($this->curl);
         }
+        $this->options = null;
         $this->json_decoder = null;
     }
 


### PR DESCRIPTION
This fixes #173.