### PR TITLE
Add data processing using the Curl::buildPostData() in the Curl::patch()

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -444,7 +444,7 @@ class Curl
         $this->setURL($url);
         $this->unsetHeader('Content-Length');
         $this->setOpt(CURLOPT_CUSTOMREQUEST, 'PATCH');
-        $this->setOpt(CURLOPT_POSTFIELDS, $data);
+        $this->setOpt(CURLOPT_POSTFIELDS, $this->buildPostData($data));
         return $this->exec();
     }
 


### PR DESCRIPTION
When I tried to send a PATCH request with data as a multidimensional array, I got the following notification "Array to string conversion Curl/Curl.php:681". Data processing using method buildPostData() fixed this issue.