### PR TITLE
Remove client_id

### DIFF
--- a/examples/domainr_search_domain_name_availability.php
+++ b/examples/domainr_search_domain_name_availability.php
@@ -5,7 +5,7 @@ use \Curl\Curl;
 
 $curl = new Curl();
 $curl->get('https://api.domainr.com/v1/search', array(
-    'client_id' => 'php_curl_class',
+    'client_id' => '{your-mashape-key}',
     'q' => 'example',
 ));
 


### PR DESCRIPTION
Due to API abuse, we're locking these down further. Details in our [API documentation](http://domainr.build/docs/authentication).