### PR TITLE
Bug Fix - unsetHeader

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -667,6 +667,18 @@ class Curl
         $this->setUserAgent($user_agent);
     }
 
+	/**
+     * Set Default Header
+	 * @param  $key
+     *
+     * @access public
+     */
+    public function setDefaultHeader($key)
+    {
+        unset($this->headers[$key]);
+        $this->buildHeaders();
+    }
+	
     /**
      * Set Header
      *
@@ -794,8 +806,7 @@ class Curl
      */
     public function unsetHeader($key)
     {
-        unset($this->headers[$key]);
-        $this->buildHeaders();
+        $this->setHeader($key, '');
     }
 
     /**

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -80,7 +80,25 @@ class Curl
     {
         $this->beforeSendFunction = $callback;
     }
+	
+	/**
+     * Build Headers
+     *
+     * @access private
+     * @param  $data
+     */
+    private function buildHeaders()
+    {
+        $headers = array();
+        foreach ($this->headers as $key => $value) {
+            $headers[$key] = $value;
+        }
+        $this->setOpt(CURLOPT_HTTPHEADER, array_map(function($value, $key) {
+            return $key . ': ' . $value;
+        }, $headers, array_keys($headers)));
 
+    }
+	
     /**
      * Build Post Data
      *
@@ -655,19 +673,11 @@ class Curl
      * @access public
      * @param  $key
      * @param  $value
-     *
-     * @return string
      */
     public function setHeader($key, $value)
     {
         $this->headers[$key] = $value;
-        $headers = array();
-        foreach ($this->headers as $key => $value) {
-            $headers[$key] = $value;
-        }
-        $this->setOpt(CURLOPT_HTTPHEADER, array_map(function($value, $key) {
-            return $key . ': ' . $value;
-        }, $headers, array_keys($headers)));
+        $this->buildHeaders();
     }
 
     /**
@@ -784,8 +794,8 @@ class Curl
      */
     public function unsetHeader($key)
     {
-        $this->setHeader($key, '');
         unset($this->headers[$key]);
+        $this->buildHeaders();
     }
 
     /**


### PR DESCRIPTION
There has a bug in unsetHeader()

-----------------

The unsetHeader bad work, 
for example

$curl->setHeader('Host','example.com');
$curl->unsetHeader('Host');
$curl->get('http://127.0.0.1/');

---------
This request is make with Header "Host" = '' (empty string), because unsetHeader bad work

with the my fix the header 'Host' with be deleted and curl auto-retrive the right header.
horever is already possible make request with header 'Host' = '' (empty string) with $curl->setHeader('Host', '' );

also remove a bad comment about fuction
   *		
-     * @return string
in setHeader()