### PR TITLE
Fix #240: Make CURLINFO_HEADER_OUT optional.

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -4,7 +4,7 @@ namespace Curl;
 
 class Curl
 {
-    const VERSION = '4.6.9';
+    const VERSION = '4.7.0';
     const DEFAULT_TIMEOUT = 30;
 
     public $curl;
@@ -313,7 +313,11 @@ class Curl
         $this->error = $this->curlError || $this->httpError;
         $this->errorCode = $this->error ? ($this->curlError ? $this->curlErrorCode : $this->httpStatusCode) : 0;
 
-        $this->requestHeaders = $this->parseRequestHeaders(curl_getinfo($this->curl, CURLINFO_HEADER_OUT));
+        // NOTE: CURLINFO_HEADER_OUT set to true is required for requestHeaders
+        // to not be empty (e.g. $curl->setOpt(CURLINFO_HEADER_OUT, true);).
+        if ($this->getOpt(CURLINFO_HEADER_OUT) === true) {
+            $this->requestHeaders = $this->parseRequestHeaders(curl_getinfo($this->curl, CURLINFO_HEADER_OUT));
+        }
         $this->responseHeaders = $this->parseResponseHeaders($this->rawResponseHeaders);
         list($this->response, $this->rawResponse) = $this->parseResponse($this->responseHeaders, $this->rawResponse);
 
@@ -693,7 +697,6 @@ class Curl
     public function setOpt($option, $value)
     {
         $required_options = array(
-            CURLINFO_HEADER_OUT    => 'CURLINFO_HEADER_OUT',
             CURLOPT_RETURNTRANSFER => 'CURLOPT_RETURNTRANSFER',
         );
 

--- a/tests/PHPCurlClass/PHPCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPCurlClassTest.php
@@ -830,6 +830,29 @@ class CurlTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($etag, $response_headers['eTaG']);
     }
 
+    public function testHeaderOutOptional()
+    {
+        // CURLINFO_HEADER_OUT is true by default.
+        $test_1 = new Test();
+        $test_1->server('response_header', 'GET');
+        $this->assertNotEmpty($test_1->curl->requestHeaders);
+        $this->assertNotEmpty($test_1->curl->requestHeaders['Request-Line']);
+
+        // CURLINFO_HEADER_OUT is set to true.
+        $test_2 = new Test();
+        $test_2->curl->setOpt(CURLINFO_HEADER_OUT, true);
+        $test_2->server('response_header', 'GET');
+        $this->assertNotEmpty($test_2->curl->requestHeaders);
+        $this->assertNotEmpty($test_2->curl->requestHeaders['Request-Line']);
+
+        // CURLINFO_HEADER_OUT is set to false.
+        $test_3 = new Test();
+        $test_3->curl->setOpt(CURLINFO_HEADER_OUT, false);
+        $test_3->curl->verbose();
+        $test_3->server('response_header', 'GET');
+        $this->assertNull($test_3->curl->requestHeaders);
+    }
+
     public function testHeaderRedirect()
     {
         $test = new Test();
@@ -2382,15 +2405,6 @@ class CurlTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_resource($curl->curl));
         $curl->close();
         $this->assertFalse(is_resource($curl->curl));
-    }
-
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
-    public function testRequiredOptionCurlInfoHeaderOutEmitsWarning()
-    {
-        $curl = new Curl();
-        $curl->setOpt(CURLINFO_HEADER_OUT, false);
     }
 
     /**


### PR DESCRIPTION
CURLINFO_HEADER_OUT is true by default, but now optional. When
CURLINFO_HEADER_OUT is not true, requestHeaders will be null.