### PR TITLE
Cookie: preserve encode space to '%20' in delimiter, when multiple cookies available

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -543,8 +543,10 @@ class Curl
      */
     public function setCookie($key, $value)
     {
-        $this->cookies[$key] = $value;
-        $this->setOpt(CURLOPT_COOKIE, str_replace(' ', '%20', urldecode(http_build_query($this->cookies, '', '; '))));
+        $this->cookies[$key] = $value;        
+        $this->setOpt(CURLOPT_COOKIE, implode('; ', array_map(function($name) { 
+            return $name . '=' . str_replace(' ', '%20', $this->cookies[$name]); 
+        }, array_keys($this->cookies)))); 
     }
 
     /**

--- a/tests/PHPCurlClass/PHPCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPCurlClassTest.php
@@ -661,6 +661,19 @@ class CurlTest extends PHPUnit_Framework_TestCase
         $options = $reflectionProperty->getValue($curl);
         $this->assertEquals('cookie=Om%20nom%20nom%20nom', $options[CURLOPT_COOKIE]);
     }
+    
+    public function testMultipleCookies()
+    {
+        $curl = new Curl();
+        $curl->setCookie('cookie', 'Om nom nom nom');
+        $curl->setCookie('foo', 'bar');
+
+        $reflectionClass = new ReflectionClass('\Curl\Curl');
+        $reflectionProperty = $reflectionClass->getProperty('options');
+        $reflectionProperty->setAccessible(true);
+        $options = $reflectionProperty->getValue($curl);
+        $this->assertEquals('cookie=Om%20nom%20nom%20nom; foo=bar', $options[CURLOPT_COOKIE]);
+    }
 
     public function testCookieEncodingColon()
     {


### PR DESCRIPTION
Setting multiple cookies to curl wrapper
```php
$curlInstance->setCookie('foo', 'bar baz');
$curlInstance->setCookie('bar', 'foo');
$curlInstance->get('', array());
```
cause Cookie header line in request as follow: ```foo=bar%20baz;%20bar=foo```.  
After changes it will be generate string like ```foo=bar%20baz; bar=foo```