### PR TITLE
Performance feature: use predefined chars arrays for setCookie() method

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -585,7 +585,7 @@ class Curl
     {
         $name_chars = array();
         foreach (str_split($key) as $name_char) {
-            if (!array_key_exists($name_char, CurlCookieConst::RFC2616)) {
+            if (!array_key_exists($name_char, CurlCookieConst::RFC2616())) {
                 $name_chars[] = rawurlencode($name_char);
             } else {
                 $name_chars[] = $name_char;
@@ -594,7 +594,7 @@ class Curl
 
         $value_chars = array();
         foreach (str_split($value) as $value_char) {
-            if (!array_key_exists($value_char, CurlCookieConst::RFC6265)) {
+            if (!array_key_exists($value_char, CurlCookieConst::RFC6265())) {
                 $value_chars[] = rawurlencode($value_char);
             } else {
                 $value_chars[] = $value_char;

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -2,6 +2,48 @@
 
 namespace Curl;
 
+abstract class CurlCookieConst
+{
+    private static $RFC2616 = array();
+    private static $RFC6265 = array();
+
+    public static function Init() {
+        self::$RFC2616 = array_fill_keys(array(
+            // RFC2616: "any CHAR except CTLs or separators".
+            '!', '#', '$', '%', '&', "'", '*', '+', '-', '.', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A',
+            'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
+            'W', 'X', 'Y', 'Z', '^', '_', '`', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+            'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '|', '~',
+        ), true);
+
+        self::$RFC6265 = array_fill_keys(array(
+            // RFC6265: "US-ASCII characters excluding CTLs, whitespace DQUOTE, comma, semicolon, and backslash".
+            // %x21
+            '!',
+            // %x23-2B
+            '#', '$', '%', '&', "'", '(', ')', '*', '+',
+            // %x2D-3A
+            '-', '.', '/', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ':',
+            // %x3C-5B
+            '<', '=', '>', '?', '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+            'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '[',
+            // %x5D-7E
+            ']', '^', '_', '`', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
+            'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '{', '|', '}', '~',
+        ), true);
+    }
+
+    public static function RFC2616() {
+        return self::$RFC2616;
+    }
+
+    public static function RFC6265() {
+        return self::$RFC6265;
+    }
+}
+
+CurlCookieConst::Init();
+
 class Curl
 {
     const VERSION = '4.8.1';
@@ -543,12 +585,7 @@ class Curl
     {
         $name_chars = array();
         foreach (str_split($key) as $name_char) {
-            if (!in_array($name_char, array(
-                // RFC2616: "any CHAR except CTLs or separators".
-                '!', '#', '$', '%', '&', "'", '*', '+', '-', '.', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A',
-                'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
-                'W', 'X', 'Y', 'Z', '^', '_', '`', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
-                'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '|', '~',), true)) {
+            if (!array_key_exists($name_char, CurlCookieConst::RFC2616)) {
                 $name_chars[] = rawurlencode($name_char);
             } else {
                 $name_chars[] = $name_char;
@@ -557,20 +594,7 @@ class Curl
 
         $value_chars = array();
         foreach (str_split($value) as $value_char) {
-            if (!in_array($value_char, array(
-                // RFC6265: "US-ASCII characters excluding CTLs, whitespace DQUOTE, comma, semicolon, and backslash".
-                // %x21
-                '!',
-                // %x23-2B
-                '#', '$', '%', '&', "'", '(', ')', '*', '+',
-                // %x2D-3A
-                '-', '.', '/', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ':',
-                // %x3C-5B
-                '<', '=', '>', '?', '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
-                'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '[',
-                // %x5D-7E
-                ']', '^', '_', '`', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
-                'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '{', '|', '}', '~',), true)) {
+            if (!array_key_exists($value_char, CurlCookieConst::RFC6265)) {
                 $value_chars[] = rawurlencode($value_char);
             } else {
                 $value_chars[] = $value_char;


### PR DESCRIPTION
Hi! 
Here https://github.com/php-curl-class/php-curl-class/compare/php-curl-class:master...maxvodo:with-benchmarking I wrote some benchmarks to examine: how we can increase performance by method ```Curl::setCookie()``` in ```in_array()``` case. 

Some results from my machine:
```
PHP 5.5.9-1ubuntu4.14 (cli) (built: Oct 28 2015 01:34:46) 
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2014 Zend Technologies
    with Zend OPcache v7.0.3, Copyright (c) 1999-2014, by Zend Technologies
    with Xdebug v2.2.3, Copyright (c) 2002-2013, by Derick Rethans

Searching benchmarks in: ./php-curl-class/tests/benchmarks
Loading benchmark from: forCookies.php
Running tests 60000 times.
Testing 1/1 :  call CookiesConsts::Init()

Test                            Time   Time (%)   Memory   Memory (%)   
 call CookiesConsts::Init()   123 ms                 0 B                

Running tests 80000 times.
Testing 8/8 :  predefined array_key_exists RFC6265

Test                                      Time   Time (%)   Memory   Memory (%)   
 predefined array_key_exists RFC6265    450 ms                 0 B                
 predefined array_key_exists RFC2616    454 ms        1 %      0 B                
 predefined in_array RFC6265            508 ms       13 %      0 B                
 predefined in_array RFC2616            513 ms       14 %      0 B                
 in_array RFC2616                       852 ms       89 %      0 B                
 in_array RFC6265                       905 ms      101 %      0 B                
 array_key_exists RFC2616              1155 ms      157 %      0 B                
 array_key_exists RFC6265              1250 ms      178 %      0 B               
```

Using of once initialized arrays it's good variant.