### PR TITLE
added php doc. phpstorm shows error on this property.

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -83,6 +83,9 @@ class Curl
     private $headers = array();
     private $options = array();
 
+    /**
+     * @var callable
+     */
     private $jsonDecoder = null;
     private $jsonPattern = '/^(?:application|text)\/(?:[a-z]+(?:[\.-][0-9a-z]+){0,}[\+\.]|x-)?json(?:-[a-z]+)?/i';
     private $xmlPattern = '~^(?:text/|application/(?:atom\+|rss\+)?)xml~i';


### PR DESCRIPTION
phpstorm v7.x shows error on this property (method parseResponse), it do not know what type of variable.