### PR TITLE
Volume fixes

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -2,7 +2,6 @@
 
 namespace Curl;
 
-
 class Curl
 {
     const VERSION = '4.11.0';

--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -40,16 +40,16 @@ class MultiCurl
     }
 
     /**
-	 * Auto Close 
-	 *
-	 * Wether to auto-close child Curl Requests one complete
-	 * 
-	 * @param bool $true (optional)
-	 * 
-	 * @return void
-	 * 
-	 * @access public 
-	 */
+     * Auto Close 
+     *
+     * Wether to auto-close child Curl Requests one complete
+     * 
+     * @param bool $true (optional)
+     * 
+     * @return void
+     * 
+     * @access public 
+     */
     public function autoClose($true = TRUE)
     {
         $this->autoClose = (bool) $true;

--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -515,7 +515,7 @@ class MultiCurl
         $running = array();
 
         do {
-            
+
             if (count($this->curls)) {
                 while (
                     ($id = key($this->curls)) != NULL &&

--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -24,7 +24,7 @@ class MultiCurl
     private $xmlDecoder = null;
 
     private $concurrency = 0;
-    private $autoClose = FALSE;
+    private $autoClose = false;
 
     /**
      * Construct
@@ -50,7 +50,7 @@ class MultiCurl
      *
      * @access public
      */
-    public function autoClose($true = TRUE)
+    public function autoClose($true = true)
     {
         $this->autoClose = (bool) $true;
     }
@@ -100,7 +100,7 @@ class MultiCurl
         if (is_callable($mixed_filename)) {
             $callback = $mixed_filename;
             $curl->downloadCompleteFunction = $callback;
-            $this->curlFileHandles[$curl->id] = TRUE;
+            $this->curlFileHandles[$curl->id] = true;
         } else {
             $filename = $mixed_filename;
             $this->curlFileHandles[$curl->id] = $filename;
@@ -518,7 +518,7 @@ class MultiCurl
 
             if (count($this->curls)) {
                 while (
-                    ($id = key($this->curls)) != NULL &&
+                    ($id = key($this->curls)) != null &&
                     ($this->concurrency <= 0 || (count($running) < $this->concurrency))
                 ) {
                     $running[$id] = $id;
@@ -636,7 +636,7 @@ class MultiCurl
     {
         if (isset($this->curlFileHandles[$curl->id])) {
             $mixed_handle = $this->curlFileHandles[$curl->id];
-            if ($mixed_handle === TRUE) {
+            if ($mixed_handle === true) {
                 $fh = tmpfile();
             } else {
                 $filename = $mixed_handle;

--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -23,6 +23,8 @@ class MultiCurl
     private $jsonDecoder = null;
     private $xmlDecoder = null;
 
+    private $autoClose = FALSE;
+
     /**
      * Construct
      *
@@ -34,6 +36,22 @@ class MultiCurl
         $this->multiCurl = curl_multi_init();
         $this->headers = new CaseInsensitiveArray();
         $this->setURL($base_url);
+    }
+
+    /**
+	 * Auto Close 
+	 *
+	 * Wether to auto-close child Curl Requests one complete
+	 * 
+	 * @param bool $true (optional)
+	 * 
+	 * @return void
+	 * 
+	 * @access public 
+	 */
+    public function autoClose($true = TRUE)
+    {
+        $this->autoClose = (bool) $true;
     }
 
     /**
@@ -511,6 +529,11 @@ class MultiCurl
                                 $ch->downloadComplete($this->curlFileHandles[$ch->id]);
                                 unset($this->curlFileHandles[$ch->id]);
                             }
+
+                            if($this->autoClose) $ch->close();
+
+                            unset($ch);
+
                             break;
                         }
                     }

--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -40,15 +40,15 @@ class MultiCurl
     }
 
     /**
-     * Auto Close 
+     * Auto Close
      *
      * Wether to auto-close child Curl Requests one complete
-     * 
+     *
      * @param bool $true (optional)
-     * 
+     *
      * @return void
-     * 
-     * @access public 
+     *
+     * @access public
      */
     public function autoClose($true = TRUE)
     {


### PR DESCRIPTION
A couple of fixes for downloads of "volume"

1. I noticed that `$mc = new MultiCurl; unset($mc);` does not call `__destruct` (in fact, `$c = new Curl; unser($c);` doesn't either) as the $ch is still referenced by `curl()`, etc, so, for convenience, I added `autoClose` that will automatically call `$ch->close()`, which will destruct the objects and free up memory consumed by them.
2. When calling many downloads, I wanted to be able to manage the concurrency of the downloads, so I added `concurrency()`.  Now, only X downloads will process at once.  This manages an internal queue, and it will process all by default (concurrency of `0`).
3. Also when managing many downloads (think, thousands) I hit a file pointer ceiling.  I mitigated this by deferring the creating of the file pointers until `initHandle()` is called, which will stay within the concurrency limits.

Hope this finds you well.