### PR TITLE
Response parsing and header parsing should depend on flags

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -76,8 +76,8 @@ class Curl
     private $headers = array();
     private $options = array();
     
-    private $responseParsing = null;
-    private $responseHeadersParsing = null;
+    private $responseParsing = true;
+    private $responseHeadersParsing = true;
     private $jsonDecoder = null;
     private $jsonPattern = '/^(?:application|text)\/(?:[a-z]+(?:[\.-][0-9a-z]+){0,}[\+\.]|x-)?json(?:-[a-z]+)?/i';
     private $xmlDecoder = null;
@@ -98,8 +98,6 @@ class Curl
 
         $this->curl = curl_init();
         $this->id = 1;
-        $this->responseParsing = true;
-        $this->responseHeadersParsing = true;
         $this->setDefaultUserAgent();
         $this->setDefaultJsonDecoder();
         $this->setDefaultXmlDecoder();
@@ -844,7 +842,7 @@ class Curl
      * @access public
      * @param  $function
      */
-    public function setJsonDecoder($function=null)
+    public function setJsonDecoder($function)
     {
         if (is_callable($function) || $function === null) {
             $this->jsonDecoder = $function;
@@ -857,7 +855,7 @@ class Curl
      * @access public
      * @param  $function
      */
-    public function setXmlDecoder($function=null)
+    public function setXmlDecoder($function)
     {
         if (is_callable($function) || $function === null) {
             $this->xmlDecoder = $function;

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -75,7 +75,8 @@ class Curl
     private $responseCookies = array();
     private $headers = array();
     private $options = array();
-
+    
+    private $responseParsing = null;
     private $jsonDecoder = null;
     private $jsonPattern = '/^(?:application|text)\/(?:[a-z]+(?:[\.-][0-9a-z]+){0,}[\+\.]|x-)?json(?:-[a-z]+)?/i';
     private $xmlDecoder = null;
@@ -96,6 +97,7 @@ class Curl
 
         $this->curl = curl_init();
         $this->id = 1;
+        $this->responseParsing = true;
         $this->setDefaultUserAgent();
         $this->setDefaultJsonDecoder();
         $this->setDefaultXmlDecoder();
@@ -358,8 +360,12 @@ class Curl
             $this->requestHeaders = $this->parseRequestHeaders(curl_getinfo($this->curl, CURLINFO_HEADER_OUT));
         }
         $this->responseHeaders = $this->parseResponseHeaders($this->rawResponseHeaders);
-        list($this->response, $this->rawResponse) = $this->parseResponse($this->responseHeaders, $this->rawResponse);
-
+        if($this->responseParsing)
+        {
+            list($this->response, $this->rawResponse) = $this->parseResponse($this->responseHeaders, $this->rawResponse);
+        } else {
+            $this->response = $this->rawResponse;
+        }
         $this->httpErrorMessage = '';
         if ($this->error) {
             if (isset($this->responseHeaders['Status-Line'])) {
@@ -801,9 +807,9 @@ class Curl
      * @access public
      * @param  $function
      */
-    public function setJsonDecoder($function)
+    public function setJsonDecoder($function=null)
     {
-        if (is_callable($function)) {
+        if (is_callable($function) || $function === null) {
             $this->jsonDecoder = $function;
         }
     }
@@ -814,9 +820,9 @@ class Curl
      * @access public
      * @param  $function
      */
-    public function setXmlDecoder($function)
+    public function setXmlDecoder($function=null)
     {
-        if (is_callable($function)) {
+        if (is_callable($function) || $function === null) {
             $this->xmlDecoder = $function;
         }
     }


### PR DESCRIPTION
A user may wish to disable the XML parsing, since when downloading to a file, such parsing shouldn't do anything, since rawResponse wouldn't contain a string anyway. 

Also should be able to disable XML or JSON parsing by giving null as a handler.
