### PR TITLE
Add PHP 7.1 to continuous integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
   - nightly
 
 matrix:
   allow_failures:
+    - php: 7.1
     - php: nightly
 
 before_script:

--- a/examples/multi_curl_upload_file.php
+++ b/examples/multi_curl_upload_file.php
@@ -1,0 +1,25 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+use \Curl\MultiCurl;
+
+$multi_curl = new MultiCurl();
+
+// HINT: If API documentation refers to using something like curl -F "myimage=image.png",
+// curl --form "myimage=image.png", or the html form is similar to <form enctype="multipart/form-data" method="post">,
+// then try uncommenting the following line:
+// $multi_curl->setHeader('Content-Type', 'multipart/form-data');
+
+$multi_curl->addPost('https://httpbin.org/post', array(
+    'image' => new CURLFile('the-lorax.jpg'),
+));
+
+$multi_curl->addPost('https://httpbin.org/post', array(
+    'image' => new CURLFile('swomee-swans.jpg'),
+));
+
+$multi_curl->addPost('https://httpbin.org/post', array(
+    'image' => new CURLFile('truffula-trees.jpg'),
+));
+
+$multi_curl->start();

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -350,7 +350,10 @@ class Curl
 
         // Include additional error code information in error message when possible.
         if ($this->curlError && function_exists('curl_strerror')) {
-            $this->curlErrorMessage = curl_strerror($this->curlErrorCode) . ': ' . $this->curlErrorMessage;
+            $this->curlErrorMessage =
+                curl_strerror($this->curlErrorCode) . (
+                    empty($this->curlErrorMessage) ? '' : ': ' . $this->curlErrorMessage
+                );
         }
 
         $this->httpStatusCode = $this->getInfo(CURLINFO_HTTP_CODE);


### PR DESCRIPTION
Include PHP 7.1 in continuous integration tests.
Append existing error message when not empty.
Fix #384: Add multi curl file upload example.