### PR TITLE
Add a curl add method for direct handle attach

### DIFF
--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -286,6 +286,19 @@ class MultiCurl
     }
 
     /**
+     * Adds a Curl instance to the handle queue
+     *
+     * @access public
+     * @param  $curl
+     *
+     * @return void
+     */
+    public function addCurl(Curl $curl)
+    {
+        $this->queueHandle($curl);
+    }
+
+    /**
      * Before Send
      *
      * @access public

--- a/tests/PHPCurlClass/PHPMultiCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPMultiCurlClassTest.php
@@ -2408,4 +2408,16 @@ class MultiCurlTest extends PHPUnit_Framework_TestCase
         });
         $multi_curl->start();
     }
+
+    public function testAddCurl()
+    {
+        $curl = new Curl\Curl();
+        $curl->setUrl(Test::TEST_URL);
+        $curl->setOpt(CURLOPT_CUSTOMREQUEST, 'GET');
+        $curl->setOpt(CURLOPT_HTTPGET, true);
+
+        $multi_curl = new MultiCurl();
+        $multi_curl->addCurl($curl);
+        $multi_curl->start();
+    }
 }


### PR DESCRIPTION
Hi,

here is a little modifiction for a direct handle attachment. I need this, because i've used the Curl object in a client implementation and i like to add those clients to multi curl handler. So it's not useful to extract the URL for the multi curl process.

Regards Kai Hempel 