### PR TITLE
fix leak memory

### DIFF
--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -652,6 +652,7 @@ class MultiCurl
                             $ch->curlErrorCode = $info_array['result'];
                             $ch->exec($ch->curl);
 
+                            $this->activeCurls[$key]->close();
                             unset($this->activeCurls[$key]);
 
                             // Start a new request before removing the handle of the completed one.


### PR DESCRIPTION
fix leak memory
**Demo**
```
$multiCurl = new MultiCurl();

for ($i0 = 0; $i0 < 10; $i0++) {
    for ($i = 0; $i <= 1000; $i++) {
        $multiCurl->addGet('http://127.0.0.1/test.php');
    }

    $multiCurl->start();

    echo $i0 . ' Memory: ' . memory_get_usage(true) / 1024 / 1024 . 'MB' . PHP_EOL;
}
echo 'Before Unset MultiCurl Memory: ' . memory_get_usage(true) / 1024 / 1024 . 'MB' . PHP_EOL;
$multiCurl->close();

unset($multiCurl);

echo 'Latest Memory: ' . memory_get_usage(true) / 1024 / 1024 . 'MB' . PHP_EOL;
```


**Result**
0 Memory: 8.25MB
1 Memory: 14.5MB
2 Memory: 21.25MB
3 Memory: 27.75MB
4 Memory: 34MB
5 Memory: 41.25MB
6 Memory: 47.5MB
7 Memory: 53.75MB
8 Memory: 59.75MB
9 Memory: 65.75MB
Before Unset MultiCurl Memory: 65.75MB
Latest Memory: 65.75MB
[Finished in 21.1s]
