### PR TITLE
Updated post method to set content-length

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -599,7 +599,11 @@ class Curl
         }
 
         $this->setOpt(CURLOPT_POST, true);
-        $this->setOpt(CURLOPT_POSTFIELDS, $this->buildPostData($data));
+        
+        $post_data = $this->buildPostData($data);
+        $this->setOpt(CURLOPT_POSTFIELDS, $post_data);
+        $this->setHeader('Content-Length', strlen($post_data));
+        
         return $this->exec();
     }
 

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -599,11 +599,10 @@ class Curl
         }
 
         $this->setOpt(CURLOPT_POST, true);
-        
         $post_data = $this->buildPostData($data);
         $this->setOpt(CURLOPT_POSTFIELDS, $post_data);
         $this->setHeader('Content-Length', strlen($post_data));
-        
+
         return $this->exec();
     }
 


### PR DESCRIPTION
The post method didn't set the content length, so on calls where it may be set (like a put) it would not get updated correctly. It now calculates the length and sets the header. Their may be other methods like get that also need it.