### PR TITLE
JSON associated array Example - Removed json index on response

### DIFF
--- a/examples/post_json_array_response.php
+++ b/examples/post_json_array_response.php
@@ -18,4 +18,4 @@ $curl = new Curl();
 $curl->setDefaultJsonDecoder($assoc = true);
 $curl->setHeader('Content-Type', 'application/json');
 $curl->post('https://httpbin.org/post', $data);
-var_dump($curl->response['json']);
+var_dump($curl->response);


### PR DESCRIPTION
The $curl->response seems to be all that is needed, the 'json' index was invalid when I tried it.