### PR TITLE
Only set CURLOPT_POSTFIELDS options if post data is not empty for DELETE method

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -265,7 +265,9 @@ class Curl
 
         $this->setUrl($url, $query_parameters);
         $this->setOpt(CURLOPT_CUSTOMREQUEST, 'DELETE');
-        $this->setOpt(CURLOPT_POSTFIELDS, $this->buildPostData($data));
+        if (!empty($data)) {
+            $this->setOpt(CURLOPT_POSTFIELDS, $this->buildPostData($data));
+        }
         return $this->exec();
     }
 


### PR DESCRIPTION
**Problem:**
When sending a delete request to Apple News API, it always returns "invalid signature" error
It's because Apple check if CURLOPT_POSTFIELDS option exists, then they will detect that request as a POST, and validate a posting action instead of deleting action.

**Solution:**
Only set CURLOPT_POSTFIELDS options if post data is not empty for DELETE method