### PR TITLE
PHP magic methods as a proxy to set curl properties

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -1475,6 +1475,31 @@ class Curl
     }
 
     /**
+     * @param string $name
+     * @param mixed $value
+     */
+    public function __set($name, $value)
+    {
+        $method = 'set' . ucfirst($name);
+        if (method_exists($this, $method)) {
+            $this->$method($value);
+        }
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        $method = 'get' . ucfirst($name);
+        if (method_exists($this, $method)) {
+            return !is_null($this->$method());
+        }
+        return false;
+    }
+
+    /**
      * Get Effective Url
      *
      * @access private


### PR DESCRIPTION
Eliminate `setXXX()`:

```php
$curl->Cookies = $cookies;
$curl->Headers = $headers;
```