### PR TITLE
Fix close() under PHP8

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -10,7 +10,7 @@ class Curl
     const VERSION = '8.9.0';
     const DEFAULT_TIMEOUT = 30;
 
-    public $curl;
+    public $curl = null;
     public $id = null;
 
     public $error = false;
@@ -211,8 +211,9 @@ class Curl
      */
     public function close()
     {
-        if (is_resource($this->curl)) {
+        if ($this->curl !== null) {
             curl_close($this->curl);
+            $this->curl = null;
         }
         $this->options = null;
         $this->jsonDecoder = null;
@@ -1457,7 +1458,7 @@ class Curl
      */
     public function reset()
     {
-        if (function_exists('curl_reset') && is_resource($this->curl)) {
+        if (function_exists('curl_reset') && $this->curl !== null) {
             curl_reset($this->curl);
         } else {
             $this->curl = curl_init();

--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -7,7 +7,7 @@ use Curl\ArrayUtil;
 class MultiCurl
 {
     public $baseUrl = null;
-    public $multiCurl;
+    public $multiCurl = null;
 
     private $curls = array();
     private $activeCurls = array();
@@ -370,8 +370,9 @@ class MultiCurl
             $curl->close();
         }
 
-        if (is_resource($this->multiCurl)) {
+        if ($this->multiCurl !== null) {
             curl_multi_close($this->multiCurl);
+            $this->multiCurl = null;
         }
     }
 


### PR DESCRIPTION
Fixes #662

At least on some platforms, maybe always with PHP8, is_resource(curl_init())===false because it returns the new \CurlHandle type instead.