### PR TITLE
Fix #686: Build url without using data parameter

### DIFF
--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -247,7 +247,7 @@ class MultiCurl
         }
 
         $this->queueHandle($curl);
-        $this->setUrl($url, $data);
+        $this->setUrl($url);
         $curl->setUrl($url);
         $curl->setOpt(CURLOPT_CUSTOMREQUEST, 'PATCH');
         $curl->setOpt(CURLOPT_POSTFIELDS, $curl->buildPostData($data));
@@ -315,7 +315,7 @@ class MultiCurl
 
         $curl = new Curl($this->baseUrl);
         $this->queueHandle($curl);
-        $this->setUrl($url, $data);
+        $this->setUrl($url);
         $curl->setUrl($url);
         $curl->setOpt(CURLOPT_CUSTOMREQUEST, 'PUT');
         $put_data = $curl->buildPostData($data);
@@ -344,7 +344,7 @@ class MultiCurl
 
         $curl = new Curl($this->baseUrl);
         $this->queueHandle($curl);
-        $this->setUrl($url, $data);
+        $this->setUrl($url);
         $curl->setUrl($url);
         $curl->setOpt(CURLOPT_CUSTOMREQUEST, 'SEARCH');
         $put_data = $curl->buildPostData($data);

--- a/tests/PHPCurlClass/PHPCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPCurlClassTest.php
@@ -4168,10 +4168,10 @@ class CurlTest extends \PHPUnit\Framework\TestCase
         $data = ['key' => 'value'];
 
         $curl = new Curl();
-        $curl->setHeader('X-DEBUG-TEST', 'post');
+        $curl->setHeader('X-DEBUG-TEST', 'patch');
         $curl->patch(Test::TEST_URL, $data);
 
-        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals('PATCH / HTTP/1.1', $curl->requestHeaders['Request-Line']);
         $this->assertEquals(Test::TEST_URL, $curl->url);
         $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
     }
@@ -4181,10 +4181,10 @@ class CurlTest extends \PHPUnit\Framework\TestCase
         $data = str_repeat('-', 100);
 
         $curl = new Curl();
-        $curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $curl->setHeader('X-DEBUG-TEST', 'patch_json');
         $curl->patch(Test::TEST_URL, $data);
 
-        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals('PATCH / HTTP/1.1', $curl->requestHeaders['Request-Line']);
         $this->assertEquals(Test::TEST_URL, $curl->url);
         $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
         $this->assertEquals($data, $curl->response);
@@ -4195,10 +4195,10 @@ class CurlTest extends \PHPUnit\Framework\TestCase
         $data = ['key' => 'value'];
 
         $curl = new Curl();
-        $curl->setHeader('X-DEBUG-TEST', 'post');
+        $curl->setHeader('X-DEBUG-TEST', 'put');
         $curl->put(Test::TEST_URL, $data);
 
-        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals('PUT / HTTP/1.1', $curl->requestHeaders['Request-Line']);
         $this->assertEquals(Test::TEST_URL, $curl->url);
         $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
     }
@@ -4208,10 +4208,10 @@ class CurlTest extends \PHPUnit\Framework\TestCase
         $data = str_repeat('-', 100);
 
         $curl = new Curl();
-        $curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $curl->setHeader('X-DEBUG-TEST', 'put_json');
         $curl->put(Test::TEST_URL, $data);
 
-        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals('PUT / HTTP/1.1', $curl->requestHeaders['Request-Line']);
         $this->assertEquals(Test::TEST_URL, $curl->url);
         $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
         $this->assertEquals($data, $curl->response);
@@ -4222,10 +4222,10 @@ class CurlTest extends \PHPUnit\Framework\TestCase
         $data = ['key' => 'value'];
 
         $curl = new Curl();
-        $curl->setHeader('X-DEBUG-TEST', 'post');
+        $curl->setHeader('X-DEBUG-TEST', 'search');
         $curl->search(Test::TEST_URL, $data);
 
-        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals('SEARCH / HTTP/1.1', $curl->requestHeaders['Request-Line']);
         $this->assertEquals(Test::TEST_URL, $curl->url);
         $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
     }
@@ -4235,10 +4235,10 @@ class CurlTest extends \PHPUnit\Framework\TestCase
         $data = str_repeat('-', 100);
 
         $curl = new Curl();
-        $curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $curl->setHeader('X-DEBUG-TEST', 'search_json');
         $curl->search(Test::TEST_URL, $data);
 
-        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals('SEARCH / HTTP/1.1', $curl->requestHeaders['Request-Line']);
         $this->assertEquals(Test::TEST_URL, $curl->url);
         $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
         $this->assertEquals($data, $curl->response);

--- a/tests/PHPCurlClass/PHPCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPCurlClassTest.php
@@ -4173,7 +4173,6 @@ class CurlTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('PATCH / HTTP/1.1', $curl->requestHeaders['Request-Line']);
         $this->assertEquals(Test::TEST_URL, $curl->url);
-        $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
     }
 
     public function testPatchDataString()
@@ -4200,7 +4199,6 @@ class CurlTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('PUT / HTTP/1.1', $curl->requestHeaders['Request-Line']);
         $this->assertEquals(Test::TEST_URL, $curl->url);
-        $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
     }
 
     public function testPutDataString()
@@ -4214,7 +4212,6 @@ class CurlTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('PUT / HTTP/1.1', $curl->requestHeaders['Request-Line']);
         $this->assertEquals(Test::TEST_URL, $curl->url);
         $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
-        $this->assertEquals($data, $curl->response);
     }
 
     public function testSearchDataArray()
@@ -4230,7 +4227,7 @@ class CurlTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
     }
 
-    public function testSearchPutDataString()
+    public function testSearchDataString()
     {
         $data = str_repeat('-', 100);
 
@@ -4241,6 +4238,5 @@ class CurlTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('SEARCH / HTTP/1.1', $curl->requestHeaders['Request-Line']);
         $this->assertEquals(Test::TEST_URL, $curl->url);
         $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
-        $this->assertEquals($data, $curl->response);
     }
 }

--- a/tests/PHPCurlClass/PHPCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPCurlClassTest.php
@@ -4162,4 +4162,85 @@ class CurlTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
         $this->assertEquals($data, $curl->response);
     }
+
+    public function testPatchDataArray()
+    {
+        $data = ['key' => 'value'];
+
+        $curl = new Curl();
+        $curl->setHeader('X-DEBUG-TEST', 'post');
+        $curl->patch(Test::TEST_URL, $data);
+
+        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals(Test::TEST_URL, $curl->url);
+        $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
+    }
+
+    public function testPatchDataString()
+    {
+        $data = str_repeat('-', 100);
+
+        $curl = new Curl();
+        $curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $curl->patch(Test::TEST_URL, $data);
+
+        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals(Test::TEST_URL, $curl->url);
+        $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
+        $this->assertEquals($data, $curl->response);
+    }
+
+    public function testPutDataArray()
+    {
+        $data = ['key' => 'value'];
+
+        $curl = new Curl();
+        $curl->setHeader('X-DEBUG-TEST', 'post');
+        $curl->put(Test::TEST_URL, $data);
+
+        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals(Test::TEST_URL, $curl->url);
+        $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
+    }
+
+    public function testPutDataString()
+    {
+        $data = str_repeat('-', 100);
+
+        $curl = new Curl();
+        $curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $curl->put(Test::TEST_URL, $data);
+
+        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals(Test::TEST_URL, $curl->url);
+        $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
+        $this->assertEquals($data, $curl->response);
+    }
+
+    public function testSearchDataArray()
+    {
+        $data = ['key' => 'value'];
+
+        $curl = new Curl();
+        $curl->setHeader('X-DEBUG-TEST', 'post');
+        $curl->search(Test::TEST_URL, $data);
+
+        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals(Test::TEST_URL, $curl->url);
+        $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
+    }
+
+    public function testSearchPutDataString()
+    {
+        $data = str_repeat('-', 100);
+
+        $curl = new Curl();
+        $curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $curl->search(Test::TEST_URL, $data);
+
+        $this->assertEquals('POST / HTTP/1.1', $curl->requestHeaders['Request-Line']);
+        $this->assertEquals(Test::TEST_URL, $curl->url);
+        $this->assertEquals(Test::TEST_URL, $curl->effectiveUrl);
+        $this->assertEquals($data, $curl->response);
+    }
 }

--- a/tests/PHPCurlClass/PHPMultiCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPMultiCurlClassTest.php
@@ -4759,11 +4759,11 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
         $data = ['key' => 'value'];
 
         $multi_curl = new MultiCurl();
-        $multi_curl->setHeader('X-DEBUG-TEST', 'post');
+        $multi_curl->setHeader('X-DEBUG-TEST', 'patch');
         $multi_curl->addPatch(Test::TEST_URL, $data);
         $multi_curl->complete(function ($instance) {
             \PHPUnit\Framework\Assert::assertEquals(
-                'POST / HTTP/1.1',
+                'PATCH / HTTP/1.1',
                 $instance->requestHeaders['Request-Line']
             );
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
@@ -4777,11 +4777,11 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
         $data = str_repeat('-', 100);
 
         $multi_curl = new MultiCurl();
-        $multi_curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $multi_curl->setHeader('X-DEBUG-TEST', 'patch_json');
         $multi_curl->addPatch(Test::TEST_URL, $data);
         $multi_curl->complete(function ($instance) use ($data) {
             \PHPUnit\Framework\Assert::assertEquals(
-                'POST / HTTP/1.1',
+                'PATCH / HTTP/1.1',
                 $instance->requestHeaders['Request-Line']
             );
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
@@ -4796,11 +4796,11 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
         $data = ['key' => 'value'];
 
         $multi_curl = new MultiCurl();
-        $multi_curl->setHeader('X-DEBUG-TEST', 'post');
+        $multi_curl->setHeader('X-DEBUG-TEST', 'put');
         $multi_curl->addPut(Test::TEST_URL, $data);
         $multi_curl->complete(function ($instance) {
             \PHPUnit\Framework\Assert::assertEquals(
-                'POST / HTTP/1.1',
+                'PUT / HTTP/1.1',
                 $instance->requestHeaders['Request-Line']
             );
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
@@ -4814,11 +4814,11 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
         $data = str_repeat('-', 100);
 
         $multi_curl = new MultiCurl();
-        $multi_curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $multi_curl->setHeader('X-DEBUG-TEST', 'put_json');
         $multi_curl->addPut(Test::TEST_URL, $data);
         $multi_curl->complete(function ($instance) use ($data) {
             \PHPUnit\Framework\Assert::assertEquals(
-                'POST / HTTP/1.1',
+                'PUT / HTTP/1.1',
                 $instance->requestHeaders['Request-Line']
             );
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
@@ -4833,11 +4833,11 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
         $data = ['key' => 'value'];
 
         $multi_curl = new MultiCurl();
-        $multi_curl->setHeader('X-DEBUG-TEST', 'post');
+        $multi_curl->setHeader('X-DEBUG-TEST', 'search');
         $multi_curl->addSearch(Test::TEST_URL, $data);
         $multi_curl->complete(function ($instance) {
             \PHPUnit\Framework\Assert::assertEquals(
-                'POST / HTTP/1.1',
+                'SEARCH / HTTP/1.1',
                 $instance->requestHeaders['Request-Line']
             );
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
@@ -4851,11 +4851,11 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
         $data = str_repeat('-', 100);
 
         $multi_curl = new MultiCurl();
-        $multi_curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $multi_curl->setHeader('X-DEBUG-TEST', 'search_json');
         $multi_curl->addSearch(Test::TEST_URL, $data);
         $multi_curl->complete(function ($instance) use ($data) {
             \PHPUnit\Framework\Assert::assertEquals(
-                'POST / HTTP/1.1',
+                'SEARCH / HTTP/1.1',
                 $instance->requestHeaders['Request-Line']
             );
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);

--- a/tests/PHPCurlClass/PHPMultiCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPMultiCurlClassTest.php
@@ -4786,7 +4786,6 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
             );
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->effectiveUrl);
-            \PHPUnit\Framework\Assert::assertEquals($data, $instance->response);
         });
         $multi_curl->start();
     }
@@ -4823,7 +4822,6 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
             );
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->effectiveUrl);
-            \PHPUnit\Framework\Assert::assertEquals($data, $instance->response);
         });
         $multi_curl->start();
     }
@@ -4860,7 +4858,6 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
             );
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
             \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->effectiveUrl);
-            \PHPUnit\Framework\Assert::assertEquals($data, $instance->response);
         });
         $multi_curl->start();
     }

--- a/tests/PHPCurlClass/PHPMultiCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPMultiCurlClassTest.php
@@ -4753,4 +4753,115 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
         });
         $multi_curl->start();
     }
+
+    public function testPatchDataArray()
+    {
+        $data = ['key' => 'value'];
+
+        $multi_curl = new MultiCurl();
+        $multi_curl->setHeader('X-DEBUG-TEST', 'post');
+        $multi_curl->addPatch(Test::TEST_URL, $data);
+        $multi_curl->complete(function ($instance) {
+            \PHPUnit\Framework\Assert::assertEquals(
+                'POST / HTTP/1.1',
+                $instance->requestHeaders['Request-Line']
+            );
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->effectiveUrl);
+        });
+        $multi_curl->start();
+    }
+
+    public function testPatchDataString()
+    {
+        $data = str_repeat('-', 100);
+
+        $multi_curl = new MultiCurl();
+        $multi_curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $multi_curl->addPatch(Test::TEST_URL, $data);
+        $multi_curl->complete(function ($instance) use ($data) {
+            \PHPUnit\Framework\Assert::assertEquals(
+                'POST / HTTP/1.1',
+                $instance->requestHeaders['Request-Line']
+            );
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->effectiveUrl);
+            \PHPUnit\Framework\Assert::assertEquals($data, $instance->response);
+        });
+        $multi_curl->start();
+    }
+
+    public function testPutDataArray()
+    {
+        $data = ['key' => 'value'];
+
+        $multi_curl = new MultiCurl();
+        $multi_curl->setHeader('X-DEBUG-TEST', 'post');
+        $multi_curl->addPut(Test::TEST_URL, $data);
+        $multi_curl->complete(function ($instance) {
+            \PHPUnit\Framework\Assert::assertEquals(
+                'POST / HTTP/1.1',
+                $instance->requestHeaders['Request-Line']
+            );
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->effectiveUrl);
+        });
+        $multi_curl->start();
+    }
+
+    public function testPutDataString()
+    {
+        $data = str_repeat('-', 100);
+
+        $multi_curl = new MultiCurl();
+        $multi_curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $multi_curl->addPut(Test::TEST_URL, $data);
+        $multi_curl->complete(function ($instance) use ($data) {
+            \PHPUnit\Framework\Assert::assertEquals(
+                'POST / HTTP/1.1',
+                $instance->requestHeaders['Request-Line']
+            );
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->effectiveUrl);
+            \PHPUnit\Framework\Assert::assertEquals($data, $instance->response);
+        });
+        $multi_curl->start();
+    }
+
+    public function testSearchDataArray()
+    {
+        $data = ['key' => 'value'];
+
+        $multi_curl = new MultiCurl();
+        $multi_curl->setHeader('X-DEBUG-TEST', 'post');
+        $multi_curl->addSearch(Test::TEST_URL, $data);
+        $multi_curl->complete(function ($instance) {
+            \PHPUnit\Framework\Assert::assertEquals(
+                'POST / HTTP/1.1',
+                $instance->requestHeaders['Request-Line']
+            );
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->effectiveUrl);
+        });
+        $multi_curl->start();
+    }
+
+    public function testSearchDataString()
+    {
+        $data = str_repeat('-', 100);
+
+        $multi_curl = new MultiCurl();
+        $multi_curl->setHeader('X-DEBUG-TEST', 'post_json');
+        $multi_curl->addSearch(Test::TEST_URL, $data);
+        $multi_curl->complete(function ($instance) use ($data) {
+            \PHPUnit\Framework\Assert::assertEquals(
+                'POST / HTTP/1.1',
+                $instance->requestHeaders['Request-Line']
+            );
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->url);
+            \PHPUnit\Framework\Assert::assertEquals(Test::TEST_URL, $instance->effectiveUrl);
+            \PHPUnit\Framework\Assert::assertEquals($data, $instance->response);
+        });
+        $multi_curl->start();
+    }
 }


### PR DESCRIPTION
Also for PATCH, PUT & SEARCH requests