### PR TITLE
Remove active curl handle when stopping requests early

### DIFF
--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -1055,7 +1055,12 @@ class MultiCurl
 
         // Attempt to stop active curl requests.
         while (count($this->activeCurls)) {
+            // Remove instance from active curls.
             $curl = array_pop($this->activeCurls);
+
+            // Remove active curl handle.
+            curl_multi_remove_handle($this->multiCurl, $curl->curl);
+
             $curl->stop();
         }
     }


### PR DESCRIPTION
Error message:
    Warning: curl_multi_info_read(): supplied resource is not a valid
    cURL handle resource in
    ./vendor/php-curl-class/php-curl-class/src/Curl/MultiCurl.php on
    line 999

#718