### PR TITLE
Fixes #707

### DIFF
--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -1015,6 +1015,8 @@ class MultiCurl
                                     throw new \ErrorException(
                                         'cURL multi add handle error: ' . curl_multi_strerror($curlm_error_code)
                                     );
+                                } else {
+                                    $curl->call($curl->beforeSendCallback);
                                 }
                             } else {
                                 $curl->execDone();


### PR DESCRIPTION
# Before

````
Message from beforeSend callback -> first attempt
Message from beforeSend callback -> first attempt

503 | https://httpbin.org/status/503
503 | https://httpbin.org/status/503

-> missed messages from second attempt

503 | https://httpbin.org/status/503
503 | https://httpbin.org/status/503 
````

# Now
````
Message from beforeSend callback
Message from beforeSend callback

503 | https://httpbin.org/status/503
Message from beforeSend callback

503 | https://httpbin.org/status/503
Message from beforeSend callback

503 | https://httpbin.org/status/503
503 | https://httpbin.org/status/503
````