### PR TITLE
Pass MultiCurl options to new Curl instances earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ More examples are available under [/examples](https://github.com/php-curl-class/
 
 ### Available Methods
 ```php
-Curl::__construct($base_url = null)
+Curl::__construct($base_url = null, $options = [])
 Curl::__destruct()
 Curl::__get($name)
 Curl::_fastDownload($url, $filename, $connections = 4) {
@@ -268,6 +268,7 @@ Curl::setCookieJar($cookie_jar)
 Curl::setCookieString($string)
 Curl::setCookies($cookies)
 Curl::setDefaultDecoder($mixed = 'json')
+Curl::setDefaultHeaderOut()
 Curl::setDefaultJsonDecoder()
 Curl::setDefaultTimeout()
 Curl::setDefaultUserAgent()

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -112,14 +112,14 @@ class Curl
      * @param  $base_url
      * @throws \ErrorException
      */
-    public function __construct($base_url = null)
+    public function __construct($base_url = null, $options = [])
     {
         if (!extension_loaded('curl')) {
             throw new \ErrorException('cURL library is not loaded');
         }
 
         $this->curl = curl_init();
-        $this->initialize($base_url);
+        $this->initialize($base_url, $options);
     }
 
     /**
@@ -1034,6 +1034,16 @@ class Curl
     }
 
     /**
+     * Set Default Header Out
+     *
+     * @access public
+     */
+    public function setDefaultHeaderOut()
+    {
+        $this->setOpt(CURLINFO_HEADER_OUT, true);
+    }
+
+    /**
      * Set Default Timeout
      *
      * @access public
@@ -1610,6 +1620,10 @@ class Curl
             $this->curl = curl_init();
         }
 
+        $this->setDefaultUserAgent();
+        $this->setDefaultTimeout();
+        $this->setDefaultHeaderOut();
+
         $this->initialize();
     }
 
@@ -2123,12 +2137,27 @@ class Curl
      * @access private
      * @param  $base_url
      */
-    private function initialize($base_url = null)
+    private function initialize($base_url = null, $options = [])
     {
+        if (isset($options)) {
+            $this->setOpts($options);
+        }
+
         $this->id = uniqid('', true);
-        $this->setDefaultUserAgent();
-        $this->setDefaultTimeout();
-        $this->setOpt(CURLINFO_HEADER_OUT, true);
+
+        // Only set default user agent if not already set.
+        if (!array_key_exists(CURLOPT_USERAGENT, $this->options)) {
+            $this->setDefaultUserAgent();
+        }
+
+        // Only set default timeout if not already set.
+        if (!array_key_exists(CURLOPT_TIMEOUT, $this->options)) {
+            $this->setDefaultTimeout();
+        }
+
+        if (!array_key_exists(CURLINFO_HEADER_OUT, $this->options)) {
+            $this->setDefaultHeaderOut();
+        }
 
         // Create a placeholder to temporarily store the header callback data.
         $header_callback_data = new \stdClass();

--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -80,7 +80,7 @@ class MultiCurl
             $url = $this->baseUrl;
         }
 
-        $curl = new Curl($this->baseUrl);
+        $curl = new Curl($this->baseUrl, $this->options);
         $this->queueHandle($curl);
         $this->setUrl($url, $query_parameters);
         $curl->setUrl($url, $query_parameters);
@@ -100,7 +100,7 @@ class MultiCurl
      */
     public function addDownload($url, $mixed_filename)
     {
-        $curl = new Curl($this->baseUrl);
+        $curl = new Curl($this->baseUrl, $this->options);
         $this->queueHandle($curl);
         $this->setUrl($url);
         $curl->setUrl($url);
@@ -166,7 +166,7 @@ class MultiCurl
             $url = $this->baseUrl;
         }
 
-        $curl = new Curl($this->baseUrl);
+        $curl = new Curl($this->baseUrl, $this->options);
         $this->queueHandle($curl);
         $this->setUrl($url, $data);
         $curl->setUrl($url, $data);
@@ -191,7 +191,7 @@ class MultiCurl
             $url = $this->baseUrl;
         }
 
-        $curl = new Curl($this->baseUrl);
+        $curl = new Curl($this->baseUrl, $this->options);
         $this->queueHandle($curl);
         $this->setUrl($url, $data);
         $curl->setUrl($url, $data);
@@ -216,7 +216,7 @@ class MultiCurl
             $url = $this->baseUrl;
         }
 
-        $curl = new Curl($this->baseUrl);
+        $curl = new Curl($this->baseUrl, $this->options);
         $this->queueHandle($curl);
         $this->setUrl($url, $data);
         $curl->setUrl($url, $data);
@@ -241,7 +241,7 @@ class MultiCurl
             $url = $this->baseUrl;
         }
 
-        $curl = new Curl($this->baseUrl);
+        $curl = new Curl($this->baseUrl, $this->options);
 
         if (is_array($data) && empty($data)) {
             $curl->removeHeader('Content-Length');
@@ -275,7 +275,7 @@ class MultiCurl
             $url = $this->baseUrl;
         }
 
-        $curl = new Curl($this->baseUrl);
+        $curl = new Curl($this->baseUrl, $this->options);
         $this->queueHandle($curl);
         $this->setUrl($url);
 
@@ -314,7 +314,7 @@ class MultiCurl
             $url = $this->baseUrl;
         }
 
-        $curl = new Curl($this->baseUrl);
+        $curl = new Curl($this->baseUrl, $this->options);
         $this->queueHandle($curl);
         $this->setUrl($url);
         $curl->setUrl($url);
@@ -343,7 +343,7 @@ class MultiCurl
             $url = $this->baseUrl;
         }
 
-        $curl = new Curl($this->baseUrl);
+        $curl = new Curl($this->baseUrl, $this->options);
         $this->queueHandle($curl);
         $this->setUrl($url);
         $curl->setUrl($url);
@@ -1260,9 +1260,6 @@ class MultiCurl
         if ($curl->xmlDecoder === null) {
             $curl->setXmlDecoder($this->xmlDecoder);
         }
-
-        // Pass options set on the MultiCurl instance to the Curl instance.
-        $curl->setOpts($this->options);
 
         // Set instance-specific options on the Curl instance when present.
         if (isset($this->instanceSpecificOptions[$curl->id])) {

--- a/tests/PHPCurlClass/PHPMultiCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPMultiCurlClassTest.php
@@ -2059,31 +2059,35 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
     public function testSetOptAndSetOptOverride()
     {
         $multi_curl_user_agent = 'multi curl user agent';
-        $curl_user_agent = 'curl user agent';
+        $curl_user_agent_2 = 'curl user agent 2';
+        $curl_user_agent_3 = 'curl user agent 3';
         $data = ['key' => 'HTTP_USER_AGENT'];
 
         $multi_curl = new MultiCurl();
         $multi_curl->setHeader('X-DEBUG-TEST', 'server');
+
         $multi_curl->setOpt(CURLOPT_USERAGENT, $multi_curl_user_agent);
 
         $get_1 = $multi_curl->addGet(Test::TEST_URL, $data);
         $get_1->complete(function ($instance) use ($multi_curl_user_agent) {
             \PHPUnit\Framework\Assert::assertEquals($multi_curl_user_agent, $instance->getOpt(CURLOPT_USERAGENT));
-        });
-
-        $get_2 = $multi_curl->addGet(Test::TEST_URL, $data);
-        $get_2->complete(function ($instance) use ($multi_curl_user_agent) {
-            \PHPUnit\Framework\Assert::assertEquals($multi_curl_user_agent, $instance->getOpt(CURLOPT_USERAGENT));
             \PHPUnit\Framework\Assert::assertEquals($multi_curl_user_agent, $instance->response);
         });
 
-        $get_3 = $multi_curl->addGet(Test::TEST_URL, $data);
-        $get_3->beforeSend(function ($instance) use ($curl_user_agent) {
-            $instance->setOpt(CURLOPT_USERAGENT, $curl_user_agent);
+        $get_2 = $multi_curl->addGet(Test::TEST_URL, $data);
+        $get_2->setOpt(CURLOPT_USERAGENT, $curl_user_agent_2);
+        $get_2->complete(function ($instance) use ($curl_user_agent_2) {
+            \PHPUnit\Framework\Assert::assertEquals($curl_user_agent_2, $instance->getOpt(CURLOPT_USERAGENT));
+            \PHPUnit\Framework\Assert::assertEquals($curl_user_agent_2, $instance->response);
         });
-        $get_3->complete(function ($instance) use ($curl_user_agent) {
-            \PHPUnit\Framework\Assert::assertEquals($curl_user_agent, $instance->getOpt(CURLOPT_USERAGENT));
-            \PHPUnit\Framework\Assert::assertEquals($curl_user_agent, $instance->response);
+
+        $get_3 = $multi_curl->addGet(Test::TEST_URL, $data);
+        $get_3->beforeSend(function ($instance) use ($curl_user_agent_3) {
+            $instance->setOpt(CURLOPT_USERAGENT, $curl_user_agent_3);
+        });
+        $get_3->complete(function ($instance) use ($curl_user_agent_3) {
+            \PHPUnit\Framework\Assert::assertEquals($curl_user_agent_3, $instance->getOpt(CURLOPT_USERAGENT));
+            \PHPUnit\Framework\Assert::assertEquals($curl_user_agent_3, $instance->response);
         });
 
         $multi_curl->start();


### PR DESCRIPTION
Fix setting of options by passing of MultiCurl options to new Curl instances earlier. Set options during the Curl initialization instead of waiting until the request instance is configured in `MultiCurl::initHandle()`.