### PR TITLE
Display request options in Curl::diagnose() output

### DIFF
--- a/tests/PHPCurlClass/PHPCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPCurlClassTest.php
@@ -4108,6 +4108,7 @@ class CurlTest extends \PHPUnit\Framework\TestCase
             '--- Begin PHP Curl Class diagnostic output ---',
             'PHP Curl Class version: ' . Curl::VERSION,
             'PHP version: ' . PHP_VERSION,
+            'CURLOPT_HTTPGET: true',
             'Sent an HTTP GET request ',
             'Request contained no body.',
             'Received an HTTP status code of 401.',


### PR DESCRIPTION
Request options are now displayed when `Curl::diagnose()` is called and a deferred constant `curlOptionCodeConstants` has been added.