### PR TITLE
silence PHP 8.2 deprecation notices

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -5,6 +5,7 @@ namespace Curl;
 use Curl\ArrayUtil;
 use Curl\Url;
 
+#[\AllowDynamicProperties]
 class Curl
 {
     const VERSION = '9.12.5';

--- a/tests/PHPCurlClass/Helper.php
+++ b/tests/PHPCurlClass/Helper.php
@@ -13,6 +13,8 @@ class Test
 
     private $testUrl;
 
+    public $curl;
+
     public function __construct($port = null)
     {
         $this->testUrl = $port === null ? self::TEST_URL : $this->getTestUrl($port);

--- a/tests/PHPCurlClass/User.php
+++ b/tests/PHPCurlClass/User.php
@@ -16,6 +16,7 @@ if (interface_exists('JsonSerializable')) {
             $this->email = $email;
         }
 
+        #[\ReturnTypeWillChange]
         public function jsonSerialize()
         {
             return [


### PR DESCRIPTION
This fixes many deprecation notices, as seen in the log output of the CI action: https://github.com/php-curl-class/php-curl-class/actions/runs/3876061846/jobs/6609437723

- `PHP Deprecated:  Creation of dynamic property Curl\Curl::$curlErrorCodeConstants is deprecated in /home/runner/work/php-curl-class/php-curl-class/src/Curl/Curl.php on line 1908`
- `PHP Deprecated:  Creation of dynamic property Helper\Test::$curl is deprecated in /home/runner/work/php-curl-class/php-curl-class/tests/PHPCurlClass/Helper.php on line 19`
- `PHP Deprecated:  Return type of Helper\User::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/php-curl-class/php-curl-class/tests/PHPCurlClass/User.php on line 19`