### PR TITLE
Allow setting dynamic properties for Curl class

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -6,6 +6,7 @@ use Curl\ArrayUtil;
 use Curl\BaseCurl;
 use Curl\Url;
 
+#[\AllowDynamicProperties]
 class Curl extends BaseCurl
 {
     const VERSION = '9.13.1';

--- a/tests/PHPCurlClass/PHPMultiCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPMultiCurlClassTest.php
@@ -5109,4 +5109,12 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(5, $instance->retries);
         $this->assertFalse($instance->error);
     }
+    
+    public function testDynamicProperty()
+    {
+        $multi_curl = new MultiCurl();
+
+        $instance = $multi_curl->addGet(Test::TEST_URL);
+        $instance->myTag = 'test'; // this should not throw an error
+    }
 }

--- a/tests/PHPCurlClass/PHPMultiCurlClassTest.php
+++ b/tests/PHPCurlClass/PHPMultiCurlClassTest.php
@@ -5109,7 +5109,7 @@ class MultiCurlTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(5, $instance->retries);
         $this->assertFalse($instance->error);
     }
-    
+
     public function testDynamicProperty()
     {
         $multi_curl = new MultiCurl();


### PR DESCRIPTION
In PHP 8.2 this
```php
foreach ($tagList as $myTag) {
    $curl = $multiCurl->addGet("baseurl", ["myTag" => $myTag]);
    $curl->myTag = $myTag; // <- this throws `Creation of dynamic property Curl\Curl::$myTag is deprecated`
}
```
leads to a `Creation of dynamic property Curl\Curl::$mytag is deprecated`.

Adding the `#[\AllowDynamicProperties]` attribute, fixes the issue.