### PR TITLE
Replace `uniqid` by `random_bytes`

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -2095,7 +2095,7 @@ class Curl extends BaseCurl
             $this->setOpts($options);
         }
 
-        $this->id = uniqid('', true);
+        $this->id = bin2hex(random_bytes(32));
 
         // Only set default user agent if not already set.
         if (!array_key_exists(CURLOPT_USERAGENT, $this->options)) {

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -2095,7 +2095,7 @@ class Curl extends BaseCurl
             $this->setOpts($options);
         }
 
-        $this->id = bin2hex(random_bytes(32));
+        $this->id = bin2hex(random_bytes(16));
 
         // Only set default user agent if not already set.
         if (!array_key_exists(CURLOPT_USERAGENT, $this->options)) {


### PR DESCRIPTION
The function `uniqid` does not guarantee that the return value is unique, despite its name. This is even acknowledged in the PHP documentation.

Instead, we should use the function `random_bytes`, which returns a cryptographically secure random value. This function is supported on all PHP versions that we support according to our requirements.