### PR TITLE
Use short array syntax

### DIFF
--- a/examples/multi_curl_set_custom_instance_tag.php
+++ b/examples/multi_curl_set_custom_instance_tag.php
@@ -9,7 +9,7 @@ $tags_to_urls = [
     'tag5' => 'https://httpbin.org/status/503',
 ];
 
-$ids_to_tags = array();
+$ids_to_tags = [];
 
 $multi_curl = new MultiCurl();
 

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -1325,7 +1325,7 @@ class Curl extends BaseCurl
         if ($this->attempts === 0) {
             echo 'No HTTP requests have been made.' . "\n";
         } else {
-            $request_types = array(
+            $request_types = [
                 'DELETE' => $this->getOpt(CURLOPT_CUSTOMREQUEST) === 'DELETE',
                 'GET' => $this->getOpt(CURLOPT_CUSTOMREQUEST) === 'GET' || $this->getOpt(CURLOPT_HTTPGET),
                 'HEAD' => $this->getOpt(CURLOPT_CUSTOMREQUEST) === 'HEAD',
@@ -1334,7 +1334,7 @@ class Curl extends BaseCurl
                 'POST' => $this->getOpt(CURLOPT_CUSTOMREQUEST) === 'POST' || $this->getOpt(CURLOPT_POST),
                 'PUT' => $this->getOpt(CURLOPT_CUSTOMREQUEST) === 'PUT',
                 'SEARCH' => $this->getOpt(CURLOPT_CUSTOMREQUEST) === 'SEARCH',
-            );
+            ];
             $request_method = '';
             foreach ($request_types as $http_method_name => $http_method_used) {
                 if ($http_method_used) {

--- a/tests/PHPCurlClass/ArrayUtilTest.php
+++ b/tests/PHPCurlClass/ArrayUtilTest.php
@@ -33,7 +33,7 @@ class ArrayUtilTest extends \PHPUnit\Framework\TestCase
 
     public function testArrayFlattenMultidimArray()
     {
-        $data = array(
+        $data = [
             'key-1' => 'value-1',
             'key-2' => 'value-2',
             'key-3' => [
@@ -44,7 +44,7 @@ class ArrayUtilTest extends \PHPUnit\Framework\TestCase
                     'nested-more-key-2' => 'nested-more-value-2',
                 ],
             ],
-        );
+        ];
 
         $this->assertEquals([
             'key-1' => 'value-1',


### PR DESCRIPTION
This pull request replaces the long syntax `array(...)` with the more concise and modern short syntax `[...]` for creating arrays.

Throughout the repository, the short syntax is already used in most cases, with the exception of these three specific instances.