### PR TITLE
Replace isset with null coalescing operator

### DIFF
--- a/src/Curl/BaseCurl.php
+++ b/src/Curl/BaseCurl.php
@@ -62,7 +62,7 @@ abstract class BaseCurl
      */
     public function getOpt($option)
     {
-        return isset($this->options[$option]) ? $this->options[$option] : null;
+        return $this->options[$option] ?? null;
     }
 
     /**

--- a/src/Curl/CaseInsensitiveArray.php
+++ b/src/Curl/CaseInsensitiveArray.php
@@ -123,7 +123,7 @@ class CaseInsensitiveArray implements \ArrayAccess, \Countable, \Iterator
     public function offsetGet($offset)
     {
         $offsetlower = strtolower($offset);
-        return isset($this->data[$offsetlower]) ? $this->data[$offsetlower] : null;
+        return $this->data[$offsetlower] ?? null;
     }
 
     /**
@@ -176,7 +176,7 @@ class CaseInsensitiveArray implements \ArrayAccess, \Countable, \Iterator
     public function key()
     {
         $key = key($this->data);
-        return isset($this->keys[$key]) ? $this->keys[$key] : $key;
+        return $this->keys[$key] ?? $key;
     }
 
     /**

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -377,8 +377,7 @@ class Curl extends BaseCurl
             return false;
         }
 
-        $content_length = isset($curl->responseHeaders['Content-Length']) ?
-            $curl->responseHeaders['Content-Length'] : null;
+        $content_length = $curl->responseHeaders['Content-Length'] ?? null;
 
         // Use a regular download when content length could not be determined.
         if (!$content_length) {
@@ -839,7 +838,7 @@ class Curl extends BaseCurl
      */
     public function getResponseCookie($key)
     {
-        return isset($this->responseCookies[$key]) ? $this->responseCookies[$key] : null;
+        return $this->responseCookies[$key] ?? null;
     }
 
     /**
@@ -1282,8 +1281,7 @@ class Curl extends BaseCurl
             $request_options_count = count($this->options);
             $request_headers_count = count($this->requestHeaders);
             $request_body_empty = empty($this->getOpt(CURLOPT_POSTFIELDS));
-            $response_header_length = isset($this->responseHeaders['Content-Length']) ?
-                $this->responseHeaders['Content-Length'] : '(not specified in response header)';
+            $response_header_length = $this->responseHeaders['Content-Length'] ?? '(not specified in response header)';
             $response_calculated_length = is_string($this->rawResponse) ?
                 strlen($this->rawResponse) : '(' . var_export($this->rawResponse, true) . ')';
             $response_headers_count = count($this->responseHeaders);
@@ -1865,7 +1863,7 @@ class Curl extends BaseCurl
             }
         }
 
-        return [isset($raw_headers['0']) ? $raw_headers['0'] : '', $http_headers];
+        return [$raw_headers['0'] ?? '', $http_headers];
     }
 
     /**

--- a/src/Curl/Url.php
+++ b/src/Curl/Url.php
@@ -127,29 +127,29 @@ class Url
         $target = [];
         if (isset($r['scheme'])) {
             $target['scheme'] = $r['scheme'];
-            $target['host'] = isset($r['host']) ? $r['host'] : null;
-            $target['port'] = isset($r['port']) ? $r['port'] : null;
-            $target['user'] = isset($r['user']) ? $r['user'] : null;
-            $target['pass'] = isset($r['pass']) ? $r['pass'] : null;
+            $target['host'] = $r['host'] ?? null;
+            $target['port'] = $r['port'] ?? null;
+            $target['user'] = $r['user'] ?? null;
+            $target['pass'] = $r['pass'] ?? null;
             $target['path'] = isset($r['path']) ? self::removeDotSegments($r['path']) : null;
-            $target['query'] = isset($r['query']) ? $r['query'] : null;
+            $target['query'] = $r['query'] ?? null;
         } else {
-            $target['scheme'] = isset($b['scheme']) ? $b['scheme'] : null;
+            $target['scheme'] = $b['scheme'] ?? null;
             if ($r['authorized']) {
-                $target['host'] = isset($r['host']) ? $r['host'] : null;
-                $target['port'] = isset($r['port']) ? $r['port'] : null;
-                $target['user'] = isset($r['user']) ? $r['user'] : null;
-                $target['pass'] = isset($r['pass']) ? $r['pass'] : null;
+                $target['host'] = $r['host'] ?? null;
+                $target['port'] = $r['port'] ?? null;
+                $target['user'] = $r['user'] ?? null;
+                $target['pass'] = $r['pass'] ?? null;
                 $target['path'] = isset($r['path']) ? self::removeDotSegments($r['path']) : null;
-                $target['query'] = isset($r['query']) ? $r['query'] : null;
+                $target['query'] = $r['query'] ?? null;
             } else {
-                $target['host'] = isset($b['host']) ? $b['host'] : null;
-                $target['port'] = isset($b['port']) ? $b['port'] : null;
-                $target['user'] = isset($b['user']) ? $b['user'] : null;
-                $target['pass'] = isset($b['pass']) ? $b['pass'] : null;
+                $target['host'] = $b['host'] ?? null;
+                $target['port'] = $b['port'] ?? null;
+                $target['user'] = $b['user'] ?? null;
+                $target['pass'] = $b['pass'] ?? null;
                 if (!isset($r['path']) || $r['path'] === '') {
                     $target['path'] = $b['path'];
-                    $target['query'] = isset($r['query']) ? $r['query'] : (isset($b['query']) ? $b['query'] : null);
+                    $target['query'] = $r['query'] ?? $b['query'] ?? null;
                 } else {
                     if (StringUtil::startsWith($r['path'], '/')) {
                         $target['path'] = self::removeDotSegments($r['path']);
@@ -160,14 +160,14 @@ class Url
                         }
                         $target['path'] = self::removeDotSegments($base . '/' . $r['path']);
                     }
-                    $target['query'] = isset($r['query']) ? $r['query'] : null;
+                    $target['query'] = $r['query'] ?? null;
                 }
             }
         }
         if ($this->relativeUrl === '') {
-            $target['fragment'] = isset($b['fragment']) ? $b['fragment'] : null;
+            $target['fragment'] = $b['fragment'] ?? null;
         } else {
-            $target['fragment'] = isset($r['fragment']) ? $r['fragment'] : null;
+            $target['fragment'] = $r['fragment'] ?? null;
         }
         $absolutized_url = $this->unparseUrl($target);
         return $absolutized_url;
@@ -239,12 +239,12 @@ class Url
     private function unparseUrl($parsed_url)
     {
         $scheme   = isset($parsed_url['scheme'])   ?       $parsed_url['scheme'] . '://' : '';
-        $user     = isset($parsed_url['user'])     ?       $parsed_url['user']           : '';
+        $user     = $parsed_url['user']                                                 ?? '';
         $pass     = isset($parsed_url['pass'])     ? ':' . $parsed_url['pass']           : '';
         $pass     = ($user || $pass)               ?       $pass . '@'                   : '';
-        $host     = isset($parsed_url['host'])     ?       $parsed_url['host']           : '';
+        $host     = $parsed_url['host']                                                 ?? '';
         $port     = isset($parsed_url['port'])     ? ':' . $parsed_url['port']           : '';
-        $path     = isset($parsed_url['path'])     ?       $parsed_url['path']           : '';
+        $path     = $parsed_url['path']                                                 ?? '';
         $query    = isset($parsed_url['query'])    ? '?' . $parsed_url['query']          : '';
         $fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment']       : '';
         $unparsed_url =  $scheme . $user . $pass . $host . $port . $path . $query . $fragment;

--- a/tests/server.php
+++ b/tests/server.php
@@ -21,11 +21,11 @@ $_PUT = [];
 $_PATCH = [];
 $_DELETE = [];
 
-$request_method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : '';
+$request_method = $_SERVER['REQUEST_METHOD'] ?? '';
 if (!array_key_exists('CONTENT_TYPE', $_SERVER) && array_key_exists('HTTP_CONTENT_TYPE', $_SERVER)) {
     $_SERVER['CONTENT_TYPE'] = $_SERVER['HTTP_CONTENT_TYPE'];
 }
-$content_type = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '';
+$content_type = $_SERVER['CONTENT_TYPE'] ?? '';
 $data_values = $_GET;
 if ($request_method === 'POST') {
     $data_values = $_POST;
@@ -52,7 +52,7 @@ if (isset($_SERVER['HTTP_X_DEBUG_TEST'])) {
 } elseif (isset($_GET['test'])) {
     $test = $_GET['test'];
 }
-$key = isset($data_values['key']) ? $data_values['key'] : '';
+$key = $data_values['key'] ?? '';
 
 if ($test === 'http_basic_auth') {
     if (!isset($_SERVER['PHP_AUTH_USER'])) {
@@ -300,7 +300,7 @@ if ($test === 'http_basic_auth') {
     if (isset($_GET['http_response_code'])) {
         http_response_code((int) $_GET['http_response_code']);
     }
-    $bytes = isset($_GET['bytes']) ? $_GET['bytes'] : 1234;
+    $bytes = $_GET['bytes'] ?? 1234;
     $str = str_repeat('.', (int) $bytes);
     header('Content-Type: application/octet-stream');
     header('Content-Length: ' . strlen($str));
@@ -456,7 +456,7 @@ if (!empty($test)) {
         $value = http_build_query($data);
     } else {
         // Return individual value when a key is specified.
-        $value = isset($data[$key]) ? $data[$key] : '';
+        $value = $data[$key] ?? '';
     }
     echo $value;
 }


### PR DESCRIPTION
Since the minimum PHP version for this project is 7, we can now use the [null coalescing operator](https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op) (`??`). This makes many expressions shorter and more readable.