### PR TITLE
Specify version for vimeo/psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpcsstandards/phpcsutils": "@alpha",
         "phpunit/phpunit": "*",
         "squizlabs/php_codesniffer": "*",
-        "vimeo/psalm": "*"
+        "vimeo/psalm": ">=5"
     },
     "suggest": {
         "ext-mbstring": "*"


### PR DESCRIPTION
For some reason an old version (0.3.14) for vimeo/psalm was being installed for PHP 8.2 and PHP 8.3.

#849