### PR TITLE
Fix CI: Use nullable type declaration

### DIFF
--- a/src/Curl/CaseInsensitiveArray.php
+++ b/src/Curl/CaseInsensitiveArray.php
@@ -42,7 +42,7 @@ class CaseInsensitiveArray implements \ArrayAccess, \Countable, \Iterator
      * @param  mixed[]              $initial (optional) Existing array to convert.
      * @return CaseInsensitiveArray
      */
-    public function __construct(array $initial = null)
+    public function __construct(?array $initial = null)
     {
         if ($initial !== null) {
             foreach ($initial as $key => $value) {

--- a/src/Curl/CaseInsensitiveArray.php
+++ b/src/Curl/CaseInsensitiveArray.php
@@ -42,7 +42,12 @@ class CaseInsensitiveArray implements \ArrayAccess, \Countable, \Iterator
      * @param  mixed[]              $initial (optional) Existing array to convert.
      * @return CaseInsensitiveArray
      */
-    public function __construct(?array $initial = null)
+    // TODO: Use a nullable type declaration when supported versions >= PHP 7.1.
+    //   Trying to use the nullable type declaration on PHP 7.0:
+    //     public function __construct(?array $initial = null)
+    //   results in:
+    //     ParseError: syntax error, unexpected '?', expecting variable (T_VARIABLE)
+    public function __construct($initial = null)
     {
         if ($initial !== null) {
             foreach ($initial as $key => $value) {


### PR DESCRIPTION
Fixes warning:
```
FILE: ./src/Curl/CaseInsensitiveArray.php
-------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-------------------------------------------------------------------------------------------------
 45 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update
    |         | the type to be explicitly nullable instead. Found implicitly nullable parameter:
    |         | $initial.
    |         | (PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated)
-------------------------------------------------------------------------------------------------
```

#858