### PR TITLE
Rate limit fix

### DIFF
--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -23,7 +23,6 @@ class MultiCurl extends BaseCurl
 
     private $rateLimit = null;
     private $rateLimitEnabled = false;
-    private $rateLimitReached = false;
     private $maxRequests = null;
     private $interval = null;
     private $intervalSeconds = null;
@@ -903,19 +902,14 @@ class MultiCurl extends BaseCurl
                 $micro_time = microtime(true);
                 $elapsed_seconds = $micro_time - $this->currentStartTime;
                 if ($elapsed_seconds <= $this->intervalSeconds) {
-                    $this->rateLimitReached = true;
                     return false;
-                } elseif ($this->rateLimitReached) {
-                    $this->rateLimitReached = false;
+                } else {
                     $this->currentStartTime = $micro_time;
                     $this->currentRequestCount = 0;
                 }
             }
-
-            return true;
-        } else {
-            return true;
         }
+        return true;
     }
 
     /**


### PR DESCRIPTION
If $elapsed_seconds > $this->intervalSeconds the first time hasRequestQuota() is called, rateLimitReached is never set to true and the limit is not enforced This can happen if the rate limit is set in a callback function some time after starting

I completely removed $rateLimitReached since its only use was in the removed condition check

Alternatively, it should be possible to reinitialize currentStartTime when setRateLimit is called, but I still don't really see the usefulness of resetting the timer only when the limit was reached in the previous interval