### PR TITLE
Fix phpcs warning

### DIFF
--- a/tests/PHPCurlClass/UrlTest.php
+++ b/tests/PHPCurlClass/UrlTest.php
@@ -11,8 +11,12 @@ class UrlTest extends \PHPUnit\Framework\TestCase
     public function testUrlPaths()
     {
         $urls_file = gzopen(__DIR__ . '/urls.csv.gz', 'r');
-        fgetcsv($urls_file); // header
-        while (($test = fgetcsv($urls_file)) !== false) {
+        $length = null;
+        $separator = ",";
+        $enclosure = "\"";
+        $escape = "\\";
+        fgetcsv($urls_file, $length, $separator, $enclosure, $escape); // header
+        while (($test = fgetcsv($urls_file, $length, $separator, $enclosure, $escape)) !== false) {
             $url = new Url($test[0], $test[1]);
             $actual_url = (string)$url;
             $expected_url = $test[2];


### PR DESCRIPTION
```
FILE: ...e/runner/work/php-curl-class/php-curl-class/tests/PHPCurlClass/UrlTest.php -------------------------------------------------------------------------------- FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 14 | WARNING | The $escape parameter must be passed when calling fgetcsv() as
    |         | its default value will change in a future PHP version.
    |         | (PHPCompatibility.ParameterValues.RemovedProprietaryCSVEscaping.DeprecatedParamNotPassed)
 15 | WARNING | The $escape parameter must be passed when calling fgetcsv() as
    |         | its default value will change in a future PHP version.
    |         | (PHPCompatibility.ParameterValues.RemovedProprietaryCSVEscaping.DeprecatedParamNotPassed)
--------------------------------------------------------------------------------
```