### PR TITLE
Use immutable setup-uv@v8.1.0 tag

### DIFF
--- a/.github/workflows/pre-commit-auto-update.yml
+++ b/.github/workflows/pre-commit-auto-update.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version-file: .python-version
 


### PR DESCRIPTION
Fix CI failure introduced in #1095. `astral-sh/setup-uv@v8` does not exist as a ref -- starting with v8, the action no longer publishes major or minor shorthand tags (security; see [v8.0.0 release notes](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0)). Pin to the immutable `v8.1.0` tag instead.