### PR TITLE
Use actions/setup-python to read .python-version

### DIFF
--- a/.github/workflows/pre-commit-auto-update.yml
+++ b/.github/workflows/pre-commit-auto-update.yml
@@ -15,10 +15,13 @@ jobs:
           ref: 'master'
           persist-credentials: false
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
           python-version-file: .python-version
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Update dependencies
         run: |


### PR DESCRIPTION
Fix CI failures from #1095:
- `setup-uv@v8` dropped the `python-version-file` input (only `python-version` remains), so the input was silently ignored.
- Without a uv-managed Python, `uv pip install --system` targeted the runner's PEP 668 externally-managed system Python and failed.

Use `actions/setup-python@v6` to consume `.python-version` and put a non-externally-managed interpreter on PATH; `setup-uv` then runs without an explicit Python input.