### PR TITLE
Enable color output in pre-commit auto-update workflow

### DIFF
--- a/.github/workflows/pre-commit-auto-update.yml
+++ b/.github/workflows/pre-commit-auto-update.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-pre-commit:
     runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Set `FORCE_COLOR=1` at the job level so `uv pip install` and `pre-commit autoupdate` produce colored output in the Actions log (CI tools default to no-color when stdout isn't a TTY).