### PR TITLE
Remove @param $curl from MultiCurl::initHandle()

### DIFF
--- a/src/Curl/MultiCurl.php
+++ b/src/Curl/MultiCurl.php
@@ -825,7 +825,6 @@ class MultiCurl extends BaseCurl
     /**
      * Init Handle
      *
-     * @param                  $curl
      * @throws \ErrorException
      */
     private function initHandle()


### PR DESCRIPTION
### The problem

`MultiCurl::initHandle()` documents a `$curl` parameter, but the method takes no
arguments. `$curl` is a local variable, pulled off the queue inside the body:

```php
/**
 * Init Handle
 *
 * @param                  $curl
 * @throws \ErrorException
 */
private function initHandle()
{
    $curl = array_shift($this->queuedCurls);
```

The only call site passes nothing either — `$this->initHandle();` at
`src/Curl/MultiCurl.php:674`.

So an editor tooltip offers an argument that does not exist, and passing one is
an error.

| Where | Documented | Actual |
|---|---|---|
| `src/Curl/MultiCurl.php:828` | `@param $curl` | no parameters; `$curl` is a local from `array_shift($this->queuedCurls)` |

### The change

Removed the `@param` line. The `@throws` tag is unchanged, nothing else is
touched, and there is no behaviour change.

### Checked

The two neighbouring `@param $curl` blocks in the same file are correct and were
left alone: `addCurl(Curl $curl)` at line 342 and `queueHandle($curl)` at line
810 both really take that argument.

CONTRIBUTING asks for a test with each change. There isn't one that fits here —
this only removes a documentation tag, so no behaviour exists to assert on.
